### PR TITLE
Ruleset: prevent false positives on Symfony polyfill code

### DIFF
--- a/PHPCompatibilitySymfonyPolyfillPHP55/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP55/ruleset.xml
@@ -13,4 +13,9 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_last_error_msgFound"/>
     </rule>
 
+    <!-- Prevent false positives being thrown when run over the code of polyfill-php55 itself. -->
+    <rule ref="PHPCompatibility.Constants.NewConstants.json_error_utf8Found">
+        <exclude-pattern>/polyfill-php55/Php55\.php$</exclude-pattern>
+    </rule>
+
 </ruleset>

--- a/PHPCompatibilitySymfonyPolyfillPHP72/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP72/ruleset.xml
@@ -15,4 +15,9 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.mb_scrubFound"/>
     </rule>
 
+    <!-- Prevent false positives being thrown when run over the code of polyfill-php55 itself. -->
+    <rule ref="PHPCompatibility.Constants.NewConstants.debug_backtrace_ignore_argsFound">
+        <exclude-pattern>/polyfill-php72/Php72\.php$</exclude-pattern>
+    </rule>
+
 </ruleset>


### PR DESCRIPTION
When `PHPCompatibility(SymfonyPolyfillPHP##)` is run over the code in the Symfony polyfill repos itself, it will detect some non-issues.

The code in the files is all wrapped within proper `defined()`, `version_compare()` and/or `function_exists()` conditions and will never be executed on incompatible PHP versions.

This simple change prevents these non-issues from being reported.

This fix does rely on people having installed the package in a directory called `polyfill-php##`.