### PR TITLE
Travis: add a check against false positives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,11 @@ sudo: false
 
 dist: trusty
 
-cache:
-  apt: true
-
 language: php
 
 ## Cache composer downloads.
 cache:
+  apt: true
   directories:
     - $HOME/.cache/composer/files
 
@@ -47,13 +45,22 @@ script:
     fi
 
   # Test the rulesets.
-  - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP54Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP54 --runtime-set testVersion 5.3
-  - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP55Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP55 --runtime-set testVersion 5.3
-  - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP56Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP56 --runtime-set testVersion 5.3
-  - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP70Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP70 --runtime-set testVersion 5.3
-  - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP71Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP71 --runtime-set testVersion 5.3
-  - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP72Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP72 --runtime-set testVersion 5.3
-  - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP73Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP73 --runtime-set testVersion 5.3
+  - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP54Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP54 --runtime-set testVersion 5.3-
+  - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP55Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP55 --runtime-set testVersion 5.3-
+  - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP56Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP56 --runtime-set testVersion 5.3-
+  - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP70Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP70 --runtime-set testVersion 5.3-
+  - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP71Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP71 --runtime-set testVersion 5.3-
+  - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP72Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP72 --runtime-set testVersion 5.3-
+  - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP73Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP73 --runtime-set testVersion 5.3-
+
+  # Check that the ruleset does not throw unnecessary errors for the compat library itself.
+  - vendor/bin/phpcs ./vendor/symfony/polyfill-php54/ --standard=PHPCompatibilitySymfonyPolyfillPHP54 --runtime-set testVersion 5.3-
+  - vendor/bin/phpcs ./vendor/symfony/polyfill-php55/ --standard=PHPCompatibilitySymfonyPolyfillPHP55 --runtime-set testVersion 5.3-
+  - vendor/bin/phpcs ./vendor/symfony/polyfill-php56/ ./vendor/symfony/polyfill-util/ --standard=PHPCompatibilitySymfonyPolyfillPHP56 --runtime-set testVersion 5.3- --ignore=*/polyfill-util/TestListener*
+  - vendor/bin/phpcs ./vendor/symfony/polyfill-php70/ --standard=PHPCompatibilitySymfonyPolyfillPHP70 --runtime-set testVersion 5.3-
+  - vendor/bin/phpcs ./vendor/symfony/polyfill-php71/ --standard=PHPCompatibilitySymfonyPolyfillPHP71 --runtime-set testVersion 5.3-
+  - vendor/bin/phpcs ./vendor/symfony/polyfill-php72/ --standard=PHPCompatibilitySymfonyPolyfillPHP72 --runtime-set testVersion 5.3-
+  - vendor/bin/phpcs ./vendor/symfony/polyfill-php73/ --standard=PHPCompatibilitySymfonyPolyfillPHP73 --runtime-set testVersion 5.3-
 
   # Validate the composer.json file.
   # @link https://getcomposer.org/doc/03-cli.md#validate

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,14 @@
     "phpcompatibility/phpcompatibility-passwordcompat" : "^1.0"
   },
   "require-dev" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+    "symfony/polyfill-php54": "dev-master",
+    "symfony/polyfill-php55": "dev-master",
+    "symfony/polyfill-php56": "dev-master",
+    "symfony/polyfill-php70": "dev-master",
+    "symfony/polyfill-php71": "dev-master",
+    "symfony/polyfill-php72": "dev-master",
+    "symfony/polyfill-php73": "dev-master"
   },
   "suggest" : {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",


### PR DESCRIPTION
This adds an additional check to the Travis build.

PR 2 added `exclude`s to the various rulesets to prevent false positives being generated when the ruleset would be run against the code of the polyfills themselves.

As the polyfills may, of course, be updated over time, we need to ensure that these excludes are still sufficient.

This adds a `dev` dependency on the actual polyfills and a check to Travis to make sure that if the ruleset is run over the polyfill code, no errors are thrown.

**Note**: this check may start failing without notice because of changes in the polyfills, but that's exactly what this check is guarding against and will prevent us from releasing a version which doesn't have the right excludes in place.

In addition to this, an automatic weekly/monthly Travis run on `master` should be turned on to make sure this check is run on a semi-regular basis.
_For now, I've turned an automatic monthly check on_

Additionally:
* I've also merged the duplicate `cache` key in the Travis script.
* And the integration tests now run against an open-ended `testVersion`.