### PR TITLE
Add `PHPCompatibilitySymfonyPolyfillPHP74` ruleset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ script:
       diff -B ./PHPCompatibilitySymfonyPolyfillPHP71/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP71/ruleset.xml")
       diff -B ./PHPCompatibilitySymfonyPolyfillPHP72/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP72/ruleset.xml")
       diff -B ./PHPCompatibilitySymfonyPolyfillPHP73/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP73/ruleset.xml")
+      diff -B ./PHPCompatibilitySymfonyPolyfillPHP74/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP74/ruleset.xml")
     fi
 
   # Test the rulesets.
@@ -52,6 +53,7 @@ script:
   - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP71Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP71 --runtime-set testVersion 5.3-
   - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP72Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP72 --runtime-set testVersion 5.3-
   - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP73Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP73 --runtime-set testVersion 5.3-
+  - vendor/bin/phpcs ./Test/SymfonyPolyfillPHP74Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP74 --runtime-set testVersion 5.3-
 
   # Check that the ruleset does not throw unnecessary errors for the compat library itself.
   - vendor/bin/phpcs ./vendor/symfony/polyfill-php54/ --standard=PHPCompatibilitySymfonyPolyfillPHP54 --runtime-set testVersion 5.3-
@@ -61,6 +63,7 @@ script:
   - vendor/bin/phpcs ./vendor/symfony/polyfill-php71/ --standard=PHPCompatibilitySymfonyPolyfillPHP71 --runtime-set testVersion 5.3-
   - vendor/bin/phpcs ./vendor/symfony/polyfill-php72/ --standard=PHPCompatibilitySymfonyPolyfillPHP72 --runtime-set testVersion 5.3-
   - vendor/bin/phpcs ./vendor/symfony/polyfill-php73/ --standard=PHPCompatibilitySymfonyPolyfillPHP73 --runtime-set testVersion 5.3-
+  - vendor/bin/phpcs ./vendor/symfony/polyfill-php74/ --standard=PHPCompatibilitySymfonyPolyfillPHP74 --runtime-set testVersion 5.3-
 
   # Validate the composer.json file.
   # @link https://getcomposer.org/doc/03-cli.md#validate

--- a/PHPCompatibilitySymfonyPolyfillPHP74/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP74/ruleset.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ruleset name="PHPCompatibilitySymfonyPolyfillPHP74">
+    <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 7.4 library.</description>
+
+    <rule ref="PHPCompatibility">
+        <!-- https://github.com/symfony/polyfill-php74/blob/master/bootstrap.php -->
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.get_mangled_object_varsFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.mb_str_splitFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.password_algosFound"/>
+    </rule>
+
+    <!-- Prevent false positives being thrown when run over the code of polyfill-php74 itself. -->
+    <rule ref="PHPCompatibility.Constants.NewConstants.password_bcryptFound">
+        <exclude-pattern>/polyfill[_-]php74/Php74\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.Constants.NewConstants.password_argon2iFound">
+        <exclude-pattern>/polyfill[_-]php74/Php74\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.Constants.NewConstants.password_argon2idFound">
+        <exclude-pattern>/polyfill[_-]php74/Php74\.php$</exclude-pattern>
+    </rule>
+
+</ruleset>

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Symfony Polyfill Library | Corresponding PHPCompatibility Ruleset | Includes
 [`polyfill-php71`](https://github.com/symfony/polyfill-php71) | `PHPCompatibilitySymfonyPolyfillPHP71` |
 [`polyfill-php72`](https://github.com/symfony/polyfill-php72) | `PHPCompatibilitySymfonyPolyfillPHP72` |
 [`polyfill-php73`](https://github.com/symfony/polyfill-php73) | `PHPCompatibilitySymfonyPolyfillPHP73` |
+[`polyfill-php74`](https://github.com/symfony/polyfill-php74) | `PHPCompatibilitySymfonyPolyfillPHP74` |
 
 > About "Includes":
 > Some polyfills have other polyfills as dependencies. If the PHPCompatibility project offers a dedicated ruleset for the polyfill dependency, that ruleset will be included in the ruleset for the higher level polyfill.
@@ -80,6 +81,7 @@ Now you can use the following commands to inspect the code in your project for P
 ./vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP71
 ./vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP72
 ./vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP73
+./vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP74
 
 # You can also combine the standards if your project uses several:
 ./vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP55,PHPCompatibilitySymfonyPolyfillPHP70,PHPCompatibilitySymfonyPolyfillPHP73

--- a/Test/SymfonyPolyfillPHP74Test.php
+++ b/Test/SymfonyPolyfillPHP74Test.php
@@ -1,0 +1,9 @@
+<?php
+/*
+ * Test file to run PHP_CodeSniffer against to make sure the polyfills are correctly excluded.
+ */
+$vars = get_mangled_object_vars($obj);
+
+$parts = mb_str_split($string, 3);
+
+var_dump( password_algos() );

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     "symfony/polyfill-php70": "dev-master",
     "symfony/polyfill-php71": "dev-master",
     "symfony/polyfill-php72": "dev-master",
-    "symfony/polyfill-php73": "dev-master"
+    "symfony/polyfill-php73": "dev-master",
+    "symfony/polyfill-php74": "dev-master"
   },
   "suggest" : {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",


### PR DESCRIPTION
The Symfony project has released a [polyfill library for PHP 7.4](https://github.com/symfony/polyfill-php74).

This adds a corresponding PHPCompatibility ruleset for this polyfill.

Includes integration test.


_Opened as Draft as the Travis changes would conflict with PR #8._