### PR TITLE
PHP 7.3 polyfill: Update the ruleset

### DIFF
--- a/PHPCompatibilitySymfonyPolyfillPHP73/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP73/ruleset.xml
@@ -8,6 +8,7 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_key_lastFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hrtimeFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.is_countableFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.jsonexceptionFound"/>
     </rule>
 
 </ruleset>

--- a/Test/SymfonyPolyfillPHP73Test.php
+++ b/Test/SymfonyPolyfillPHP73Test.php
@@ -5,3 +5,5 @@
 if ( is_countable( $abc ) ) {
 	$a = hrtime() ? array_key_first() : array_key_last();
 }
+
+class MyException extends JsonException {}


### PR DESCRIPTION
A polyfill for the `JsonException` class was added in v 1.11.0 of the `polyfill-php73` package.

Ref:
* https://github.com/symfony/polyfill-php73/commit/d1fb4abcc0c47be136208ad9d68bf59f1ee17abd