### PR TITLE
PHP 7.2 Polyfill: prevent triggering new error in test

### DIFF
--- a/Test/SymfonyPolyfillPHP72Test.php
+++ b/Test/SymfonyPolyfillPHP72Test.php
@@ -7,4 +7,4 @@ $a = PHP_OS_FAMILY ? utf8_encode($b) : utf_decode($b);
 $c = stream_isatty();
 $d = sapi_windows_vt100_support();
 
-$e = mb_scrub(mb_ord(mb_chr(spl_object_id())));
+$e = mb_scrub(mb_ord(mb_chr(spl_object_id(), $encoding), $encoding), $encoding);


### PR DESCRIPTION
The test file is only supposed to check that the polyfill provided functions are correctly excluded.

However, the new `PHPCompatibility.ParameterValues.NewIconvMbstringCharsetDefault` was being triggered too as the test file did not pass all the parameters.

Fixed now.