### PR TITLE
PHP 7.2 ruleset: prevent "false" positive when run over the polyfill

### DIFF
--- a/PHPCompatibilitySymfonyPolyfillPHP72/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP72/ruleset.xml
@@ -19,5 +19,8 @@
     <rule ref="PHPCompatibility.Constants.NewConstants.debug_backtrace_ignore_argsFound">
         <exclude-pattern>/polyfill-php72/Php72\.php$</exclude-pattern>
     </rule>
+    <rule ref="PHPCompatibility.ParameterValues.NewIconvMbstringCharsetDefault.NotSet">
+        <exclude-pattern>/polyfill-php72/Php72\.php$</exclude-pattern>
+    </rule>
 
 </ruleset>


### PR DESCRIPTION
Well, not actually a false positive, but code which given the parameters passed can not be corrected.

Either way, if PHPCompatibility is run over the polyfill, it shouldn't worry people about this (non-)issue.