### PR TITLE
PHP 5.6 polyfill ruleset: bug fix / LDAP constants

### DIFF
--- a/PHPCompatibilitySymfonyPolyfillPHP56/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP56/ruleset.xml
@@ -6,6 +6,8 @@
         <!-- https://github.com/symfony/polyfill-php56/blob/master/bootstrap.php -->
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hash_equalsFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.ldap_escapeFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.ldap_escape_filterFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.ldap_escape_dnFound"/>
     </rule>
 
 </ruleset>

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ All code within the PHPCompatibility organisation is released under the GNU Less
 
 ## Changelog
 
+### Unreleased
+* `PHPCompatibilitySymfonyPolyfillPHP56` ruleset: allow for two polyfilled LDAP constants (undocumented in the Polyfill docs)
+* Composer: The recommended version of the [Composer PHPCS plugin](https://github.com/Dealerdirect/phpcodesniffer-composer-installer/) has been upped to `^0.6.0`.
+
 ### 1.1.1 - 2019-08-30
 
 * `PHPCompatibilitySymfonyPolyfillPHP72` ruleset: minor tweak to prevent false positive when the sniffs are run over the polyfill itself.

--- a/Test/SymfonyPolyfillPHP56Test.php
+++ b/Test/SymfonyPolyfillPHP56Test.php
@@ -4,3 +4,5 @@
  */
 $a = hash_equals();
 $a = ldap_escape();
+
+$var = LDAP_ESCAPE_FILTER + LDAP_ESCAPE_DN;


### PR DESCRIPTION
The Symfony PHP 5.6 polyfill appears to also [backfill two LDAP constants](https://github.com/symfony/polyfill-php56/blob/d51ec491c8ddceae7dca8dd6c7e30428f543f37d/bootstrap.php#L19-L20).

This is not mentioned in the readme documentation and may have been missed when the polyfill ruleset was originally pulled as those constants may not have been sniffed for by PHPCompatibility at that time.

Either way, fixed now.

Includes changelog entry in the readme.