### PR TITLE
Travis: minor tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 dist: trusty
 
 language: php
@@ -13,7 +11,7 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - php: 7.3
+    - php: 7.4
       addons:
         apt:
           packages:
@@ -29,7 +27,7 @@ before_install:
 
 script:
   - |
-    if [[ $TRAVIS_PHP_VERSION == "7.3" ]]; then
+    if [[ $TRAVIS_PHP_VERSION == "7.4" ]]; then
       # Validate the xml files.
       # @link http://xmlsoft.org/xmllint.html
       xmllint --noout ./*/ruleset.xml


### PR DESCRIPTION
* Support for `sudo` has been removed for quite a while now.
* Let's use PHP 7.4 as the "high" PHP version.