### PR TITLE
PHP 7.2 polyfill: Update the ruleset

### DIFF
--- a/PHPCompatibilitySymfonyPolyfillPHP72/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP72/ruleset.xml
@@ -4,12 +4,16 @@
 
     <rule ref="PHPCompatibility">
         <!-- https://github.com/symfony/polyfill-php72/blob/master/bootstrap.php -->
+        <exclude name="PHPCompatibility.Constants.NewConstants.php_float_digFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.php_float_epsilonFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.php_float_minFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.php_float_maxFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.php_os_familyFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.sapi_windows_vt100_supportFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.stream_isattyFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.utf8_encodeFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.utf8_decodeFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_object_idFound"/>
-        <exclude name="PHPCompatibility.Constants.NewConstants.php_os_familyFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.mb_ordFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.mb_chrFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.mb_scrubFound"/>

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ All code within the PHPCompatibility organisation is released under the GNU Less
 
 ## Changelog
 
+### 1.1.3 - 2020-07-19
+
+* `PHPCompatibilitySymfonyPolyfillPHP72` ruleset: allow for four polyfilled `PHP_FLOAT_*` constants, which were added in `polyfill-php72` version `1.16.0`.
+
 ### 1.1.2 - 2020-05-20
 
 * `PHPCompatibilitySymfonyPolyfillPHP56` ruleset: allow for two polyfilled LDAP constants (undocumented in the Polyfill docs)

--- a/Test/SymfonyPolyfillPHP72Test.php
+++ b/Test/SymfonyPolyfillPHP72Test.php
@@ -8,3 +8,5 @@ $c = stream_isatty();
 $d = sapi_windows_vt100_support();
 
 $e = mb_scrub(mb_ord(mb_chr(spl_object_id(), $encoding), $encoding), $encoding);
+
+$floats = PHP_FLOAT_DIG + PHP_FLOAT_EPSILON + PHP_FLOAT_MIN + PHP_FLOAT_MAX;


### PR DESCRIPTION
Polyfills for four `PHP_FLOAT_*` constants were added in v 1.16.0 of the `polyfill-php72` package.

Ref:
* https://github.com/symfony/polyfill-php72/commit/42fda6d7380e5c940d7f68341ccae89d5ab9963b

**Note:** This commit is release ready, including changelog entry.
Release date set to ~~July 15th 2020~~ July 19th 2020.