### PR TITLE
Update version of Composer PHPCS plugin + fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,19 @@ matrix:
         apt:
           packages:
             - libxml2-utils
+      install:
+        - composer install
+
     - php: 5.4
+      install:
+        - composer require --no-update symfony/polyfill-php72:"1.19" symfony/polyfill-php73:"1.19" symfony/polyfill-php74:"1.19"
+        - composer install
 
     - php: 7.4
       env: PHPCOMPAT="dev-develop as 9.99.99"
+      install:
+        - composer config minimum-stability dev
+        - composer require --no-update phpcompatibility/php-compatibility:"${PHPCOMPAT}"
 
   allow_failures:
     # Allow failures for unstable builds.
@@ -30,12 +39,8 @@ before_install:
   # Speed up build time by disabling Xdebug when its not needed.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
   - export XMLLINT_INDENT="    "
-  - |
-    if [[ $PHPCOMPAT ]]; then
-      composer config minimum-stability dev
-      composer require --no-update phpcompatibility/php-compatibility:"${PHPCOMPAT}"
-    fi
-  - composer install
+
+before_script:
   - vendor/bin/phpcs -i
 
 script:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The only supported installation method is via [Composer](https://getcomposer.org
 
 If you don't have a Composer plugin installed to manage the `installed_paths` setting for PHP_CodeSniffer, run the following from the command-line:
 ```bash
-composer require --dev dealerdirect/phpcodesniffer-composer-installer:^0.6 phpcompatibility/phpcompatibility-symfony:*
+composer require --dev dealerdirect/phpcodesniffer-composer-installer:"^0.7" phpcompatibility/phpcompatibility-symfony:*
 composer install
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "phpcompatibility/phpcompatibility-passwordcompat" : "^1.0"
   },
   "require-dev" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.6",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
     "symfony/polyfill-php54": "dev-master",
     "symfony/polyfill-php55": "dev-master",
     "symfony/polyfill-php56": "dev-master",
@@ -34,7 +34,7 @@
     "symfony/polyfill-php74": "dev-master"
   },
   "suggest" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
     "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
   },
   "prefer-stable" : true

--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,14 @@
   },
   "require-dev" : {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-    "symfony/polyfill-php54": "dev-master",
-    "symfony/polyfill-php55": "dev-master",
-    "symfony/polyfill-php56": "dev-master",
-    "symfony/polyfill-php70": "dev-master",
-    "symfony/polyfill-php71": "dev-master",
-    "symfony/polyfill-php72": "dev-master",
-    "symfony/polyfill-php73": "dev-master",
-    "symfony/polyfill-php74": "dev-master"
+    "symfony/polyfill-php54": "1.19",
+    "symfony/polyfill-php55": "1.19",
+    "symfony/polyfill-php56": "1.19",
+    "symfony/polyfill-php70": "1.19",
+    "symfony/polyfill-php71": "1.19",
+    "symfony/polyfill-php72": "dev-main",
+    "symfony/polyfill-php73": "dev-main",
+    "symfony/polyfill-php74": "dev-main"
   },
   "suggest" : {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",


### PR DESCRIPTION
### Update version of Composer PHPCS plugin

The DealerDirect Composer plugin has released version `0.7.0` a few months ago, which is compatible with Composer 2.x.
As Composer 2.0 has just been released, we should make sure not to recommend installing an older version of the plugin than `0.7.0`.

We also need to make sure we use the right version of the plugin ourselves in the `require-dev`.

As Composer treats minors < 1.0 as majors, updating to this version requires an update to the `composer.json` requirements.

> For pre-1.0 versions it also acts with safety in mind and treats ^0.3 as >=0.3.0 <0.4.0.

Refs:
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.7.0
* https://getcomposer.org/doc/articles/versions.md#caret-version-range-

### Travis: fix the build

1. The polyfill `master` branches have been renamed to `main`.
2. There's been a snafu in the Polyfill meta-repo.
    They've updated the minimum PHP version to PHP 7.1 and intended to make the polyfills for PHP < 7.2 stand-alone, but they actually rolled the minimum change out to the packages and tagged a release, which makes any version of the polyfills for PHP < 7.2 useless as they can no longer be installed. _sigh_
    Left a comment in the PR upstream. Hopefully they'll fix this in one way or another, but in the mean time, `1.19` is the last installable version of these polyfills.

I've fixed this for now by moving the `install` instructions to the jobs matrix and letting each build have its own variation to allow the packages to install.

