### PR TITLE
GH Actions: allow for manually triggering a workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
   # Also run this workflow on day 15 of every month as the repo isn't that active.
   schedule:
     - cron: '0 0 15 * *'
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   xmllint:


### PR DESCRIPTION
Triggering a workflow for a branch manually is not supported by default in GH Actions, but has to be explicitly allowed.

Ref: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/