### PR TITLE
CI/GH Action: fix failing build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,13 +118,28 @@ jobs:
           vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP74Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP74 --runtime-set testVersion 5.3-
 
       # Check that the rulesets don't throw unnecessary errors for the compat libraries themselves.
-      - name: Test running against the polyfills
+      # Note: the polyfills for PHP 5.4 - 7.1 have been decoupled from the monorepo at version 1.19.
+      # and are no longer updated.
+      - name: Test running against the polyfills - polyfills 5.4-7.1
         run: |
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php54/ --standard=PHPCompatibilitySymfonyPolyfillPHP54 --runtime-set testVersion 5.3-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php55/ --standard=PHPCompatibilitySymfonyPolyfillPHP55 --runtime-set testVersion 5.3-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php56/ ./vendor/symfony/polyfill-util/ --standard=PHPCompatibilitySymfonyPolyfillPHP56 --runtime-set testVersion 5.3- --ignore=*/polyfill-util/TestListener*
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php70/ --standard=PHPCompatibilitySymfonyPolyfillPHP70 --runtime-set testVersion 5.3-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php71/ --standard=PHPCompatibilitySymfonyPolyfillPHP71 --runtime-set testVersion 5.3-
+
+      # The polyfills for PHP 7.2 and higher are compatible with PHP 5.3+ at version 1.19.
+      - name: Test running against the polyfills - polyfills 7.2-
+        if: ${{ matrix.php == '5.4' }}
+        run: |
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php72/ --standard=PHPCompatibilitySymfonyPolyfillPHP72 --runtime-set testVersion 5.3-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php73/ --standard=PHPCompatibilitySymfonyPolyfillPHP73 --runtime-set testVersion 5.3-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php74/ --standard=PHPCompatibilitySymfonyPolyfillPHP74 --runtime-set testVersion 5.3-
+
+      # The polyfills for PHP 7.2 and higher are compatible with PHP 7.1+ at version 1.20 and above.
+      - name: Test running against the polyfills - polyfills 7.2-
+        if: ${{ matrix.php != '5.4' }}
+        run: |
+          vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php72/ --standard=PHPCompatibilitySymfonyPolyfillPHP72 --runtime-set testVersion 7.1-
+          vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php73/ --standard=PHPCompatibilitySymfonyPolyfillPHP73 --runtime-set testVersion 7.1-
+          vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php74/ --standard=PHPCompatibilitySymfonyPolyfillPHP74 --runtime-set testVersion 7.1-

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ For example:
 # For a project which should be compatible with PHP 5.3 up to and including PHP 7.0:
 ./vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP56 --runtime-set testVersion 5.3-7.0
 
-# For a project which should be compatible with PHP 5.4 and higher:
-./vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP73 --runtime-set testVersion 5.4-
+# For a project which should be compatible with PHP 7.1 and higher:
+./vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP73 --runtime-set testVersion 7.1-
 ```
 
 For more detailed information about setting the `testVersion`, see the README of the generic [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions) standard.


### PR DESCRIPTION
For those polyfill repos which are still actively maintained (PHP 7.2 and higher), the minimum required PHP version has been raised to PHP 7.1.

The polyfill repos rely on the Composer version negotation to serve the correct package version for the PHP version on which the install is run.

With that in mind, we should rely on the same and presume that if the polyfills are installed at version 1.20 or higher, that their minimum supported PHP version is PHP 7.1.