### PR TITLE
Add `PHPCompatibilitySymfonyPolyfillPHP80` ruleset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           diff -B ./PHPCompatibilitySymfonyPolyfillPHP72/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP72/ruleset.xml")
           diff -B ./PHPCompatibilitySymfonyPolyfillPHP73/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP73/ruleset.xml")
           diff -B ./PHPCompatibilitySymfonyPolyfillPHP74/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP74/ruleset.xml")
+          diff -B ./PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml")
 
   test:
     needs: xmllint
@@ -89,6 +90,10 @@ jobs:
       - name: Conditionally require specific versions of the polyfills
         if: ${{ matrix.php == '5.4' }}
         run: |
+          # Remove the PHP 8 polyfill on PHP < 7 as the minimum requirement is PHP 7.1 and the autoloading
+          # of the polyfill bootstrap file via Composer would generate a parse error, blocking the DealerDirect plugin
+          # from setting the installed_paths for PHPCS.
+          composer remove --dev symfony/polyfill-php80 --no-update --no-scripts
           composer require --no-update symfony/polyfill-php72:"1.19" symfony/polyfill-php73:"1.19" symfony/polyfill-php74:"1.19"
 
       - name: Conditionally update PHPCompatibility to develop version
@@ -117,6 +122,12 @@ jobs:
           vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP73Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP73 --runtime-set testVersion 5.3-
           vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP74Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP74 --runtime-set testVersion 5.3-
 
+      - name: Test the PHP 8.0 ruleset
+        # The PHP 8.0 polyfill has a minimum PHP requirement of PHP 7.1.
+        if: ${{ matrix.php != '5.4' }}
+        run: |
+          vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP80Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP80 --runtime-set testVersion 7.1-
+
       # Check that the rulesets don't throw unnecessary errors for the compat libraries themselves.
       # Note: the polyfills for PHP 5.4 - 7.1 have been decoupled from the monorepo at version 1.19.
       # and are no longer updated.
@@ -143,3 +154,5 @@ jobs:
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php72/ --standard=PHPCompatibilitySymfonyPolyfillPHP72 --runtime-set testVersion 7.1-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php73/ --standard=PHPCompatibilitySymfonyPolyfillPHP73 --runtime-set testVersion 7.1-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php74/ --standard=PHPCompatibilitySymfonyPolyfillPHP74 --runtime-set testVersion 7.1-
+          vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php80/ --standard=PHPCompatibilitySymfonyPolyfillPHP80 --runtime-set testVersion 7.1-
+

--- a/PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ruleset name="PHPCompatibilitySymfonyPolyfillPHP80">
+    <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 8.0 library.</description>
+
+    <rule ref="PHPCompatibility">
+        <!-- https://github.com/symfony/polyfill-php80/blob/master/bootstrap.php -->
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.fdivFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.get_resource_idFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.preg_last_error_msgFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_containsFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_ends_withFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_starts_withFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.filter_validate_boolFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.get_debug_typeFound"/>
+
+        <!-- https://github.com/symfony/polyfill-php80/tree/master/Resources/stubs -->
+        <exclude name="PHPCompatibility.Interfaces.NewInterfaces.stringableFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.attributeFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.unhandledmatcherrorFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.valueerrorFound"/>
+    </rule>
+
+</ruleset>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Symfony Polyfill Library | Corresponding PHPCompatibility Ruleset | Includes
 [`polyfill-php72`](https://github.com/symfony/polyfill-php72) | `PHPCompatibilitySymfonyPolyfillPHP72` |
 [`polyfill-php73`](https://github.com/symfony/polyfill-php73) | `PHPCompatibilitySymfonyPolyfillPHP73` |
 [`polyfill-php74`](https://github.com/symfony/polyfill-php74) | `PHPCompatibilitySymfonyPolyfillPHP74` |
+[`polyfill-php80`](https://github.com/symfony/polyfill-php80) | `PHPCompatibilitySymfonyPolyfillPHP80` |
 
 > About "Includes":
 > Some polyfills have other polyfills as dependencies. If the PHPCompatibility project offers a dedicated ruleset for the polyfill dependency, that ruleset will be included in the ruleset for the higher level polyfill.
@@ -82,6 +83,7 @@ Now you can use the following commands to inspect the code in your project for P
 ./vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP72
 ./vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP73
 ./vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP74
+./vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP80
 
 # You can also combine the standards if your project uses several:
 ./vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP55,PHPCompatibilitySymfonyPolyfillPHP70,PHPCompatibilitySymfonyPolyfillPHP73

--- a/Test/SymfonyPolyfillPHP80Test.php
+++ b/Test/SymfonyPolyfillPHP80Test.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * Test file to run PHP_CodeSniffer against to make sure the polyfills are correctly excluded.
+ */
+
+class Foo implements Stringable {}
+
+$fdiv = fdiv(10, 3);
+
+try {
+    $chars = count_chars($string, 5);
+} catch(ValueError $e) {
+}
+
+$bool = filter_var('yes', FILTER_VALIDATE_BOOL);
+
+$debug = get_debug_type($bar);
+
+if (preg_last_error_msg() !== 'No error') {
+    exit;
+}
+
+if (str_contains($haystack, $needle)) {}
+if (str_starts_with($haystack, $needle)) {}
+if (str_ends_with($haystack, $needle)) {}
+
+$id = get_resource_id($res);
+
+try {
+    // Match expression.
+} catch(UnhandledMatchError $e) {
+}
+
+class MyAttributes extends \Attribute {}

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     "symfony/polyfill-php71": "1.19",
     "symfony/polyfill-php72": "dev-main",
     "symfony/polyfill-php73": "dev-main",
-    "symfony/polyfill-php74": "dev-main"
+    "symfony/polyfill-php74": "dev-main",
+    "symfony/polyfill-php80": "dev-main"
   },
   "suggest" : {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",


### PR DESCRIPTION
The Symfony project has released a [polyfill library for PHP 8.0](https://github.com/symfony/polyfill-php80).

This adds a corresponding PHPCompatibility ruleset for this polyfill.

Includes integration test.

Note: not all excludes are "active" yet as by far not all PHP 8.0 features are included in the last PHPCompatibility release (9.3.5). However, these excludes will be "activated" once PHPCompatibility 10.0.0 is released, so we may as well add them already.