### PR TITLE
PHP 8.0 polyfill: Update the ruleset

### DIFF
--- a/PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml
@@ -16,6 +16,7 @@
         <!-- https://github.com/symfony/polyfill-php80/tree/master/Resources/stubs -->
         <exclude name="PHPCompatibility.Interfaces.NewInterfaces.stringableFound"/>
         <exclude name="PHPCompatibility.Classes.NewClasses.attributeFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.phptokenFound"/>
         <exclude name="PHPCompatibility.Classes.NewClasses.unhandledmatcherrorFound"/>
         <exclude name="PHPCompatibility.Classes.NewClasses.valueerrorFound"/>
     </rule>

--- a/Test/SymfonyPolyfillPHP80Test.php
+++ b/Test/SymfonyPolyfillPHP80Test.php
@@ -32,3 +32,5 @@ try {
 }
 
 class MyAttributes extends \Attribute {}
+
+if (is_a($token, PhpToken::class)) {}


### PR DESCRIPTION
A polyfill for the `PhpToken` class was added in v 1.25.0 of the `polyfill-php80` package.

Ref:
* https://github.com/symfony/polyfill-php80/commit/752f73db72cd90d081e9a7eeb29c5f26e06dc987