### PR TITLE
Composer: fix the branch names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,10 @@
     "symfony/polyfill-php56": "1.19",
     "symfony/polyfill-php70": "1.19",
     "symfony/polyfill-php71": "1.19",
-    "symfony/polyfill-php72": "dev-main",
-    "symfony/polyfill-php73": "dev-main",
-    "symfony/polyfill-php74": "dev-main",
-    "symfony/polyfill-php80": "dev-main"
+    "symfony/polyfill-php72": "1.x-dev",
+    "symfony/polyfill-php73": "1.x-dev",
+    "symfony/polyfill-php74": "1.x-dev",
+    "symfony/polyfill-php80": "1.x-dev"
   },
   "suggest" : {
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",


### PR DESCRIPTION
The polyfill `main` branches have been renamed to `1.x` and the alias the repos define is incorrect and thus not working....