### PR TITLE
Ruleset file: add schema tags to the ruleset

### DIFF
--- a/PHPCompatibilitySymfonyPolyfillPHP54/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP54/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="PHPCompatibilitySymfonyPolyfillPHP54">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilitySymfonyPolyfillPHP54" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 5.4 library.</description>
 
     <rule ref="PHPCompatibility">

--- a/PHPCompatibilitySymfonyPolyfillPHP55/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP55/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="PHPCompatibilitySymfonyPolyfillPHP55">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilitySymfonyPolyfillPHP55" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 5.5 library.</description>
 
     <!-- https://github.com/symfony/polyfill-php55/blob/main/composer.json -->

--- a/PHPCompatibilitySymfonyPolyfillPHP56/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP56/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="PHPCompatibilitySymfonyPolyfillPHP56">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilitySymfonyPolyfillPHP56" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 5.6 libary.</description>
 
     <rule ref="PHPCompatibility">

--- a/PHPCompatibilitySymfonyPolyfillPHP70/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP70/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="PHPCompatibilitySymfonyPolyfillPHP70">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilitySymfonyPolyfillPHP70" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 7.0 library.</description>
 
     <!-- https://github.com/symfony/polyfill-php70/blob/main/composer.json -->

--- a/PHPCompatibilitySymfonyPolyfillPHP71/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP71/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="PHPCompatibilitySymfonyPolyfillPHP71">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilitySymfonyPolyfillPHP71" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 7.1 library.</description>
 
     <rule ref="PHPCompatibility">

--- a/PHPCompatibilitySymfonyPolyfillPHP72/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP72/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="PHPCompatibilitySymfonyPolyfillPHP72">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilitySymfonyPolyfillPHP72" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 7.2 library.</description>
 
     <rule ref="PHPCompatibility">

--- a/PHPCompatibilitySymfonyPolyfillPHP73/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP73/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="PHPCompatibilitySymfonyPolyfillPHP73">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilitySymfonyPolyfillPHP73" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 7.3 library.</description>
 
     <rule ref="PHPCompatibility">

--- a/PHPCompatibilitySymfonyPolyfillPHP74/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP74/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="PHPCompatibilitySymfonyPolyfillPHP74">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilitySymfonyPolyfillPHP74" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 7.4 library.</description>
 
     <rule ref="PHPCompatibility">

--- a/PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="PHPCompatibilitySymfonyPolyfillPHP80">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilitySymfonyPolyfillPHP80" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 8.0 library.</description>
 
     <rule ref="PHPCompatibility">


### PR DESCRIPTION
As of PHPCS 3.2.0, PHPCS offers an XSD schema for rulesets which defines what can be used in the XML ruleset file.

As of a couple of weeks ago, the XSD schema is now available via permalinks.

This commit adds the relevant schema tags to the PHPCS Ruleset file(s).

Refs:
* squizlabs/PHP_CodeSniffer#1433
* https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.2.0
* PHPCSStandards/PHP_CodeSniffer#1094
* https://github.com/PHPCSStandards/schema.phpcodesniffer.com