### PR TITLE
GH Actions: don't run cron jobs on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
 
 jobs:
   xmllint:
+    # Don't run the cron job on forks.
+    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
+
     name: 'Check XML'
     runs-on: ubuntu-latest
 
@@ -55,6 +58,9 @@ jobs:
           diff -B ./PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml")
 
   test:
+    # Don't run the cron job on forks.
+    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
+
     needs: xmllint
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
While workflows are disabled by default in forks, it is quite common for contributors to enable them to verify CI will pass before submitting a pull request.

When enabling workflow runs in forks, it's "all or nothing". This means that:
* All workflows which are only intended to be run on the canonical repo will also be enabled. These workflows will also often need access to repo-specific secrets and will typically fail when run from a fork.
* Workflows which contain cron jobs will also be enabled. Depending on the type of account the contributor has, this can burn through their "CI minutes".

This commit is based on a review of workflows containing cron jobs and disables running the jobs when a cron job is triggered in a fork.