### PR TITLE
Add `PHPCompatibilitySymfonyPolyfillPHP81` ruleset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
           diff -B ./PHPCompatibilitySymfonyPolyfillPHP73/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP73/ruleset.xml")
           diff -B ./PHPCompatibilitySymfonyPolyfillPHP74/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP74/ruleset.xml")
           diff -B ./PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml")
+          diff -B ./PHPCompatibilitySymfonyPolyfillPHP81/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP81/ruleset.xml")
 
   test:
     # Don't run the cron job on forks.
@@ -105,16 +106,16 @@ jobs:
       - name: "Conditionally require specific versions of the polyfills (PHP 5.4)"
         if: ${{ matrix.php == '5.4' }}
         run: |
-          # Remove the PHP 8 polyfill on PHP < 7 as the minimum requirement is PHP 7.1 and the autoloading
+          # Remove the PHP 8.x polyfills on PHP < 7 as the minimum requirement is PHP 7.1 and the autoloading
           # of the polyfill bootstrap file via Composer would generate a parse error, blocking the DealerDirect plugin
           # from setting the installed_paths for PHPCS.
-          composer remove --dev symfony/polyfill-php80 --no-update --no-scripts --no-interaction
+          composer remove --dev symfony/polyfill-php80 symfony/polyfill-php81 --no-update --no-scripts --no-interaction
           composer require --no-update symfony/polyfill-php72:"1.19" symfony/polyfill-php73:"1.19" symfony/polyfill-php74:"1.19" --no-interaction
 
       - name: "Conditionally require specific versions of the polyfills (PHP 7.1)"
         if: ${{ matrix.php == '7.1' }}
         run: |
-          composer require --no-update symfony/polyfill-php73:"1.30" symfony/polyfill-php74:"1.30" symfony/polyfill-php80:"1.30" --no-interaction
+          composer require --no-update symfony/polyfill-php73:"1.30" symfony/polyfill-php74:"1.30" symfony/polyfill-php80:"1.30" symfony/polyfill-php81:"1.30" --no-interaction
 
       - name: Conditionally update PHPCompatibility to develop version
         if: ${{ matrix.phpcompat != 'stable' }}
@@ -142,11 +143,12 @@ jobs:
           vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP73Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP73 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 5.3-
           vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP74Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP74 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 5.3-
 
-      - name: Test the PHP 8.0 ruleset
-        # The PHP 8.0 polyfill has a minimum PHP requirement of PHP 7.1.
+      - name: Test the PHP 8.x rulesets
+        # The PHP 8.x polyfills have a minimum PHP requirement of PHP 7.1.
         if: ${{ matrix.php != '5.4' }}
         run: |
-          vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP80Test.php --exclude=PHPCompatibility.Upgrade.LowPHP --standard=PHPCompatibilitySymfonyPolyfillPHP80 --runtime-set testVersion 7.1-
+          vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP80Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP80  --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
+          vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP81Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP81  --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
 
       # Check that the rulesets don't throw unnecessary errors for the compat libraries themselves.
       # Note: the polyfills for PHP 5.4 - 7.1 have been decoupled from the monorepo at version 1.19.
@@ -176,6 +178,7 @@ jobs:
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php73/ --standard=PHPCompatibilitySymfonyPolyfillPHP73 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php74/ --standard=PHPCompatibilitySymfonyPolyfillPHP74 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php80/ --standard=PHPCompatibilitySymfonyPolyfillPHP80 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
+          vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php81/ --standard=PHPCompatibilitySymfonyPolyfillPHP81  --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
 
       # The polyfills for PHP 7.3 and higher are compatible with PHP 7.2+ at the current version.
       - name: "Test running against the polyfills - polyfills 7.3- (current)"
@@ -184,3 +187,4 @@ jobs:
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php73/ --standard=PHPCompatibilitySymfonyPolyfillPHP73 --runtime-set testVersion 7.2-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php74/ --standard=PHPCompatibilitySymfonyPolyfillPHP74 --runtime-set testVersion 7.2-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php80/ --standard=PHPCompatibilitySymfonyPolyfillPHP80 --runtime-set testVersion 7.2-
+          vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php81/ --standard=PHPCompatibilitySymfonyPolyfillPHP81 --runtime-set testVersion 7.2-

--- a/PHPCompatibilitySymfonyPolyfillPHP81/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP81/ruleset.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilitySymfonyPolyfillPHP81" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
+    <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 8.1 library.</description>
+
+    <rule ref="PHPCompatibility">
+        <!-- https://github.com/symfony/polyfill-php81/blob/main/bootstrap.php -->
+        <exclude name="PHPCompatibility.Constants.NewConstants.mysqli_refresh_replicaFound"/>
+        <exclude name="PHPCompatibility.Constants.RemovedConstants.mysqli_refresh_replicaDeprecated"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_is_listFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.enum_existsFound"/>
+
+        <!-- https://github.com/symfony/polyfill-php81/tree/main/Resources/stubs -->
+        <exclude name="PHPCompatibility.Classes.NewClasses.curlstringfileFound"/>
+    </rule>
+
+    <!-- Prevent false positives being thrown when run over the code of polyfill-php81 itself. -->
+    <rule ref="PHPCompatibility.Classes.NewClasses.attributeFound">
+        <exclude-pattern>/polyfill-php81/Resources/stubs/ReturnTypeWillChange\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.Attributes.NewAttributes.PHPNativeAttributeFound">
+        <exclude-pattern>/polyfill-php81/Resources/stubs/ReturnTypeWillChange\.php$</exclude-pattern>
+    </rule>
+
+</ruleset>

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ These rulesets prevent false positives from the [PHPCompatibility standard][PHPC
 | [`polyfill-php73`]       | `PHPCompatibilitySymfonyPolyfillPHP73` |                                                                      |
 | [`polyfill-php74`]       | `PHPCompatibilitySymfonyPolyfillPHP74` |                                                                      |
 | [`polyfill-php80`]       | `PHPCompatibilitySymfonyPolyfillPHP80` |                                                                      |
+| [`polyfill-php81`]       | `PHPCompatibilitySymfonyPolyfillPHP81` |                                                                      |
 
 > [!NOTE]
 > About "Includes":
@@ -97,6 +98,7 @@ vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP72
 vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP73
 vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP74
 vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP80
+vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP81
 
 # You can also combine the standards if your project uses several:
 vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP55,PHPCompatibilitySymfonyPolyfillPHP70,PHPCompatibilitySymfonyPolyfillPHP73
@@ -150,3 +152,4 @@ All code within the PHPCompatibility organisation is released under the GNU Less
 [`polyfill-php73`]:           https://github.com/symfony/polyfill-php73
 [`polyfill-php74`]:           https://github.com/symfony/polyfill-php74
 [`polyfill-php80`]:           https://github.com/symfony/polyfill-php80
+[`polyfill-php81`]:           https://github.com/symfony/polyfill-php81

--- a/Test/SymfonyPolyfillPHP81Test.php
+++ b/Test/SymfonyPolyfillPHP81Test.php
@@ -1,0 +1,14 @@
+<?php
+/*
+ * Test file to run PHP_CodeSniffer against to make sure the polyfills are correctly excluded.
+ */
+
+if (array_is_list($array) === true) {}
+
+$exists = enum_exists(name::class);
+
+echo MYSQLI_REFRESH_REPLICA;
+
+class Foo extends ReturnTypeWillChange {}
+
+$file = new CURLStringFile();

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     "symfony/polyfill-php72": "1.30",
     "symfony/polyfill-php73": "1.x-dev",
     "symfony/polyfill-php74": "1.x-dev",
-    "symfony/polyfill-php80": "1.x-dev"
+    "symfony/polyfill-php80": "1.x-dev",
+    "symfony/polyfill-php81": "1.x-dev"
   },
   "prefer-stable" : true
 }


### PR DESCRIPTION
The Symfony project has released a [polyfill library for PHP 8.1](https://github.com/symfony/polyfill-php81) and what with the release of PHPCompatibility 10.0.0-alpha1, features polyfilled by that library would now be flagged.

This adds a corresponding PHPCompatibility ruleset for this polyfill.

Includes integration test.

Fixes #34