### PR TITLE
Add `PHPCompatibilitySymfonyPolyfillPHP82` ruleset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           diff -B ./PHPCompatibilitySymfonyPolyfillPHP74/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP74/ruleset.xml")
           diff -B ./PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml")
           diff -B ./PHPCompatibilitySymfonyPolyfillPHP81/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP81/ruleset.xml")
+          diff -B ./PHPCompatibilitySymfonyPolyfillPHP82/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP82/ruleset.xml")
 
   test:
     # Don't run the cron job on forks.
@@ -109,13 +110,13 @@ jobs:
           # Remove the PHP 8.x polyfills on PHP < 7 as the minimum requirement is PHP 7.1 and the autoloading
           # of the polyfill bootstrap file via Composer would generate a parse error, blocking the DealerDirect plugin
           # from setting the installed_paths for PHPCS.
-          composer remove --dev symfony/polyfill-php80 symfony/polyfill-php81 --no-update --no-scripts --no-interaction
+          composer remove --dev symfony/polyfill-php80 symfony/polyfill-php81 symfony/polyfill-php82 --no-update --no-scripts --no-interaction
           composer require --no-update symfony/polyfill-php72:"1.19" symfony/polyfill-php73:"1.19" symfony/polyfill-php74:"1.19" --no-interaction
 
       - name: "Conditionally require specific versions of the polyfills (PHP 7.1)"
         if: ${{ matrix.php == '7.1' }}
         run: |
-          composer require --no-update symfony/polyfill-php73:"1.30" symfony/polyfill-php74:"1.30" symfony/polyfill-php80:"1.30" symfony/polyfill-php81:"1.30" --no-interaction
+          composer require --no-update symfony/polyfill-php73:"1.30" symfony/polyfill-php74:"1.30" symfony/polyfill-php80:"1.30" symfony/polyfill-php81:"1.30" symfony/polyfill-php82:"1.30" --no-interaction
 
       - name: Conditionally update PHPCompatibility to develop version
         if: ${{ matrix.phpcompat != 'stable' }}
@@ -149,6 +150,7 @@ jobs:
         run: |
           vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP80Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP80  --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
           vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP81Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP81  --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
+          vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP82Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP82 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
 
       # Check that the rulesets don't throw unnecessary errors for the compat libraries themselves.
       # Note: the polyfills for PHP 5.4 - 7.1 have been decoupled from the monorepo at version 1.19.
@@ -179,6 +181,7 @@ jobs:
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php74/ --standard=PHPCompatibilitySymfonyPolyfillPHP74 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php80/ --standard=PHPCompatibilitySymfonyPolyfillPHP80 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php81/ --standard=PHPCompatibilitySymfonyPolyfillPHP81  --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
+          vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php82/ --standard=PHPCompatibilitySymfonyPolyfillPHP82 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
 
       # The polyfills for PHP 7.3 and higher are compatible with PHP 7.2+ at the current version.
       - name: "Test running against the polyfills - polyfills 7.3- (current)"
@@ -188,3 +191,4 @@ jobs:
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php74/ --standard=PHPCompatibilitySymfonyPolyfillPHP74 --runtime-set testVersion 7.2-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php80/ --standard=PHPCompatibilitySymfonyPolyfillPHP80 --runtime-set testVersion 7.2-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php81/ --standard=PHPCompatibilitySymfonyPolyfillPHP81 --runtime-set testVersion 7.2-
+          vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php82/ --standard=PHPCompatibilitySymfonyPolyfillPHP82 --runtime-set testVersion 7.2-

--- a/PHPCompatibilitySymfonyPolyfillPHP82/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP82/ruleset.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilitySymfonyPolyfillPHP82" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
+    <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 8.2 library.</description>
+
+    <rule ref="PHPCompatibility">
+        <!-- https://github.com/symfony/polyfill-php82/blob/master/bootstrap.php -->
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.odbc_connection_string_is_quotedFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.odbc_connection_string_should_quoteFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.odbc_connection_string_quoteFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.ini_parse_quantityFound"/>
+
+        <!-- https://github.com/symfony/polyfill-php82/tree/main/Resources/stubs -->
+        <!--
+        Detection for the AllowDynamicProperties and SensitiveParameter attributes is incomplete in PHPCompatibility 10.0.0-alpha1.
+        This section should be filled out once the detection implementation is known.
+        -->
+
+        <!-- https://github.com/symfony/polyfill-php82/tree/main/Resources/stubs/Random -->
+        <exclude name="PHPCompatibility.Classes.NewClasses.random_brokenrandomengineerrorFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.random_randomerrorFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.random_randomexceptionFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.random_engine_secureFound"/>
+        <exclude name="PHPCompatibility.Interfaces.NewInterfaces.random_cryptosafeengineFound"/>
+        <exclude name="PHPCompatibility.Interfaces.NewInterfaces.random_engineFound"/>
+    </rule>
+
+    <!-- Prevent false positives being thrown when run over the code of polyfill-php82 itself. -->
+    <rule ref="PHPCompatibility.Attributes.NewAttributes.PHPNativeAttributeFound">
+        <exclude-pattern>/polyfill-php82/Resources/stubs/AllowDynamicProperties\.php$</exclude-pattern>
+        <exclude-pattern>/polyfill-php82/Resources/stubs/SensitiveParameter\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.Classes.NewClasses.attributeFound">
+        <exclude-pattern>/polyfill-php82/Resources/stubs/AllowDynamicProperties\.php$</exclude-pattern>
+        <exclude-pattern>/polyfill-php82/Resources/stubs/SensitiveParameter\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.Namespaces.ReservedNames.randomFound">
+        <exclude-pattern>/polyfill-php82/Resources/stubs/Random/*\.php$</exclude-pattern>
+    </rule>
+
+</ruleset>

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ These rulesets prevent false positives from the [PHPCompatibility standard][PHPC
 | [`polyfill-php74`]       | `PHPCompatibilitySymfonyPolyfillPHP74` |                                                                      |
 | [`polyfill-php80`]       | `PHPCompatibilitySymfonyPolyfillPHP80` |                                                                      |
 | [`polyfill-php81`]       | `PHPCompatibilitySymfonyPolyfillPHP81` |                                                                      |
+| [`polyfill-php82`]       | `PHPCompatibilitySymfonyPolyfillPHP82` |                                                                      |
 
 > [!NOTE]
 > About "Includes":  
@@ -99,6 +100,7 @@ vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP73
 vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP74
 vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP80
 vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP81
+vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP82
 
 # You can also combine the standards if your project uses several:
 vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP55,PHPCompatibilitySymfonyPolyfillPHP70,PHPCompatibilitySymfonyPolyfillPHP73
@@ -153,3 +155,4 @@ All code within the PHPCompatibility organisation is released under the GNU Less
 [`polyfill-php74`]:           https://github.com/symfony/polyfill-php74
 [`polyfill-php80`]:           https://github.com/symfony/polyfill-php80
 [`polyfill-php81`]:           https://github.com/symfony/polyfill-php81
+[`polyfill-php82`]:           https://github.com/symfony/polyfill-php82

--- a/Test/SymfonyPolyfillPHP82Test.php
+++ b/Test/SymfonyPolyfillPHP82Test.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Test file to run PHP_CodeSniffer against to make sure the polyfills are correctly excluded.
+ */
+
+odbc_connection_string_is_quoted($str);
+odbc_connection_string_should_quote($str);
+odbc_connection_string_quote($str);
+echo ini_parse_quantity($shorthand);
+
+class MyEngine implements Random\Engine {}
+$cl = function (
+    Random\CryptoSafeEngine $param
+): Random\Engine\Secure {
+    // Do something.
+};
+
+try {
+} catch (Random\BrokenRandomEngineError $e) {
+} catch (Random\RandomException $e) {
+} catch (Random\RandomError $e) {
+}
+
+echo AllowDynamicProperties::class;
+
+#[AllowDynamicProperties]
+class HasDynamicProperties {}
+
+if (is_a($token, SensitiveParameterValue::class)) {}
+
+/*
+// This test will not help at this time as we can't just ignore the use of the SensitiveParameter attribute
+// with the current attribute handling in PHPCompatibility 10.0.
+function hasSensitiveData(
+    #[SensitiveParameter]
+    string $password
+) {}
+*/

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
     "symfony/polyfill-php73": "1.x-dev",
     "symfony/polyfill-php74": "1.x-dev",
     "symfony/polyfill-php80": "1.x-dev",
-    "symfony/polyfill-php81": "1.x-dev"
+    "symfony/polyfill-php81": "1.x-dev",
+    "symfony/polyfill-php82": "1.x-dev"
   },
   "prefer-stable" : true
 }


### PR DESCRIPTION
The Symfony project has released a [polyfill library for PHP 8.2](https://github.com/symfony/polyfill-php82) and what with the release of PHPCompatibility 10.0-alpha1, features polyfilled by that library would now be flagged.

This adds a corresponding PHPCompatibility ruleset for this polyfill.

Includes integration test.