### PR TITLE
Add `PHPCompatibilitySymfonyPolyfillPHP83` ruleset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
           diff -B ./PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml")
           diff -B ./PHPCompatibilitySymfonyPolyfillPHP81/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP81/ruleset.xml")
           diff -B ./PHPCompatibilitySymfonyPolyfillPHP82/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP82/ruleset.xml")
+          diff -B ./PHPCompatibilitySymfonyPolyfillPHP83/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP83/ruleset.xml")
 
   test:
     # Don't run the cron job on forks.
@@ -110,13 +111,13 @@ jobs:
           # Remove the PHP 8.x polyfills on PHP < 7 as the minimum requirement is PHP 7.1 and the autoloading
           # of the polyfill bootstrap file via Composer would generate a parse error, blocking the DealerDirect plugin
           # from setting the installed_paths for PHPCS.
-          composer remove --dev symfony/polyfill-php80 symfony/polyfill-php81 symfony/polyfill-php82 --no-update --no-scripts --no-interaction
+          composer remove --dev symfony/polyfill-php80 symfony/polyfill-php81 symfony/polyfill-php82 symfony/polyfill-php83 --no-update --no-scripts --no-interaction
           composer require --no-update symfony/polyfill-php72:"1.19" symfony/polyfill-php73:"1.19" symfony/polyfill-php74:"1.19" --no-interaction
 
       - name: "Conditionally require specific versions of the polyfills (PHP 7.1)"
         if: ${{ matrix.php == '7.1' }}
         run: |
-          composer require --no-update symfony/polyfill-php73:"1.30" symfony/polyfill-php74:"1.30" symfony/polyfill-php80:"1.30" symfony/polyfill-php81:"1.30" symfony/polyfill-php82:"1.30" --no-interaction
+          composer require --no-update symfony/polyfill-php73:"1.30" symfony/polyfill-php74:"1.30" symfony/polyfill-php80:"1.30" symfony/polyfill-php81:"1.30" symfony/polyfill-php82:"1.30" symfony/polyfill-php83:"1.30" --no-interaction
 
       - name: Conditionally update PHPCompatibility to develop version
         if: ${{ matrix.phpcompat != 'stable' }}
@@ -151,6 +152,7 @@ jobs:
           vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP80Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP80  --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
           vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP81Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP81  --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
           vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP82Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP82 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
+          vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP83Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP83 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
 
       # Check that the rulesets don't throw unnecessary errors for the compat libraries themselves.
       # Note: the polyfills for PHP 5.4 - 7.1 have been decoupled from the monorepo at version 1.19.
@@ -182,6 +184,8 @@ jobs:
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php80/ --standard=PHPCompatibilitySymfonyPolyfillPHP80 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php81/ --standard=PHPCompatibilitySymfonyPolyfillPHP81  --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php82/ --standard=PHPCompatibilitySymfonyPolyfillPHP82 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
+          # The PHP 8.3 polyfills at version 1.30 are not tested against PHP 7.1 as they are not in actual fact
+          # compatible with PHP 7.1. This was correctly detected by PHPCompatibility and would cause this test to fail.
 
       # The polyfills for PHP 7.3 and higher are compatible with PHP 7.2+ at the current version.
       - name: "Test running against the polyfills - polyfills 7.3- (current)"
@@ -192,3 +196,4 @@ jobs:
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php80/ --standard=PHPCompatibilitySymfonyPolyfillPHP80 --runtime-set testVersion 7.2-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php81/ --standard=PHPCompatibilitySymfonyPolyfillPHP81 --runtime-set testVersion 7.2-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php82/ --standard=PHPCompatibilitySymfonyPolyfillPHP82 --runtime-set testVersion 7.2-
+          vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php83/ --standard=PHPCompatibilitySymfonyPolyfillPHP83 --runtime-set testVersion 7.2-

--- a/PHPCompatibilitySymfonyPolyfillPHP83/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP83/ruleset.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilitySymfonyPolyfillPHP83" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
+    <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 8.3 library.</description>
+
+    <rule ref="PHPCompatibility">
+        <!-- https://github.com/symfony/polyfill-php83/blob/master/bootstrap.php -->
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_validateFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.mb_str_padFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.stream_context_set_optionsFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_incrementFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_decrementFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.ldap_exop_syncFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.ldap_connect_walletFound"/>
+
+        <!-- https://github.com/symfony/polyfill-php83/tree/main/Resources/stubs -->
+        <!--
+        Detection for the Override attributes is incomplete in PHPCompatibility 10.0.0-alpha1.
+        Handling for this should be added once the detection implementation is known.
+        -->
+        <exclude name="PHPCompatibility.Classes.NewClasses.dateerrorFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.dateexceptionFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.dateinvalidoperationexceptionFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.dateinvalidtimezoneexceptionFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.datemalformedintervalstringexceptionFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.datemalformedperiodstringexceptionFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.datemalformedstringexceptionFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.dateobjecterrorFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.daterangeerrorFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.sqlite3exceptionFound"/>
+    </rule>
+
+    <!-- Prevent false positives being thrown when run over the code of polyfill-php83 itself. -->
+    <rule ref="PHPCompatibility.Attributes.NewAttributes.PHPNativeAttributeFound">
+        <exclude-pattern>/polyfill-php83/Resources/stubs/Override\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.Classes.NewClasses.attributeFound">
+        <exclude-pattern>/polyfill-php83/Resources/stubs/Override\.php$</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.FunctionUse.OptionalToRequiredFunctionParameters.stream_context_set_option_option_nameSoftRequired">
+        <exclude-pattern>/polyfill-php83/bootstrap\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.FunctionUse.OptionalToRequiredFunctionParameters.stream_context_set_option_valueSoftRequired">
+        <exclude-pattern>/polyfill-php83/bootstrap\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.FunctionUse.RemovedFunctionParameters.ldap_exop_response_dataDeprecated">
+        <exclude-pattern>/polyfill-php83/bootstrap\.php$</exclude-pattern>
+        <exclude-pattern>/polyfill-php83/bootstrap81\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.FunctionUse.RemovedFunctionParameters.ldap_exop_response_oidDeprecated">
+        <exclude-pattern>/polyfill-php83/bootstrap\.php$</exclude-pattern>
+        <exclude-pattern>/polyfill-php83/bootstrap81\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.ParameterValues.RemovedLdapConnectSignatures.DeprecatedThreePlusParamSignature">
+        <exclude-pattern>/polyfill-php83/bootstrap\.php$</exclude-pattern>
+        <exclude-pattern>/polyfill-php83/bootstrap81\.php$</exclude-pattern>
+    </rule>
+
+    <!-- These are fine as this file will only be used for PHP 8.1 and 8.2. -->
+    <rule ref="PHPCompatibility.Classes.NewClasses.ldap_connectionFound">
+        <exclude-pattern>/polyfill-php83/bootstrap81\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.FunctionUse.NewFunctionParameters.ldap_exop_controlsFound">
+        <exclude-pattern>/polyfill-php83/bootstrap81\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.UnionTypeFound">
+        <exclude-pattern>/polyfill-php83/bootstrap81\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.falseFound">
+        <exclude-pattern>/polyfill-php83/bootstrap81\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.Attributes.NewAttributes.PHPNativeAttributeFound">
+        <exclude-pattern>/polyfill-php83/bootstrap81\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.Attributes.NewAttributes.FoundInline">
+        <exclude-pattern>/polyfill-php83/bootstrap81\.php$</exclude-pattern>
+    </rule>
+
+    <!--
+    Not a false positive, but a bug in the Symfony PHP 8.3 polyfill package.
+    Bug has been reported: https://github.com/symfony/polyfill/issues/499#issuecomment-3430297592
+    Temporarily silencing the error as this needs to be solved upstream.
+    -->
+    <rule ref="PHPCompatibility.Classes.NewClasses.valueerrorFound">
+        <exclude-pattern>/polyfill-php83/Php83\.php$</exclude-pattern>
+    </rule>
+
+    <!--
+    Not a false positive, but a bug in the Symfony PHP 8.3 polyfill package.
+    Bug has been reported: https://github.com/symfony/polyfill/issues/550
+    Temporarily silencing the error as this needs to be solved upstream.
+    -->
+    <rule ref="PHPCompatibility.FunctionUse.NewFunctionParameters.ldap_exop_controlsFound">
+        <exclude-pattern>/polyfill-php83/bootstrap\.php$</exclude-pattern>
+    </rule>
+
+</ruleset>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ These rulesets prevent false positives from the [PHPCompatibility standard][PHPC
 | [`polyfill-php80`]       | `PHPCompatibilitySymfonyPolyfillPHP80` |                                                                      |
 | [`polyfill-php81`]       | `PHPCompatibilitySymfonyPolyfillPHP81` |                                                                      |
 | [`polyfill-php82`]       | `PHPCompatibilitySymfonyPolyfillPHP82` |                                                                      |
+| [`polyfill-php83`]       | `PHPCompatibilitySymfonyPolyfillPHP83` |                                                                      |
 
 > [!NOTE]
 > About "Includes":  
@@ -101,6 +102,7 @@ vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP74
 vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP80
 vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP81
 vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP82
+vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP83
 
 # You can also combine the standards if your project uses several:
 vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP55,PHPCompatibilitySymfonyPolyfillPHP70,PHPCompatibilitySymfonyPolyfillPHP73
@@ -156,3 +158,4 @@ All code within the PHPCompatibility organisation is released under the GNU Less
 [`polyfill-php80`]:           https://github.com/symfony/polyfill-php80
 [`polyfill-php81`]:           https://github.com/symfony/polyfill-php81
 [`polyfill-php82`]:           https://github.com/symfony/polyfill-php82
+[`polyfill-php83`]:           https://github.com/symfony/polyfill-php83

--- a/Test/SymfonyPolyfillPHP83Test.php
+++ b/Test/SymfonyPolyfillPHP83Test.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * Test file to run PHP_CodeSniffer against to make sure the polyfills are correctly excluded.
+ */
+
+json_validate($json, $depth);
+mb_str_pad($string, $length);
+str_increment($string);
+str_decrement($string);
+
+stream_context_set_options($context, $options);
+ldap_exop_sync($ldap, $request_oid);
+ldap_connect_wallet($uri, $wallet, $password);
+
+echo Override::class;
+
+class Foo extends DateError {}
+
+if (is_a($token, DateException::class)) {}
+
+try {
+} catch (DateInvalidOperationException | DateInvalidTimeZoneException $e) {
+} catch (DateMalformedIntervalStringException | DateMalformedPeriodStringException | DateMalformedStringException $e) {
+} catch (DateObjectError | DateRangeError $e) {
+} catch (SQLite3Exception $e) {
+}

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
     "symfony/polyfill-php74": "1.x-dev",
     "symfony/polyfill-php80": "1.x-dev",
     "symfony/polyfill-php81": "1.x-dev",
-    "symfony/polyfill-php82": "1.x-dev"
+    "symfony/polyfill-php82": "1.x-dev",
+    "symfony/polyfill-php83": "1.x-dev"
   },
   "prefer-stable" : true
 }


### PR DESCRIPTION
The Symfony project has released a [polyfill library for PHP 8.3](https://github.com/symfony/polyfill-php83) and what with the release of PHPCompatibility 10.0.0-alpha1, features polyfilled by that library would now be flagged.

This adds a corresponding PHPCompatibility ruleset for this polyfill.

Includes integration test.

Note: while creating this polyfill ruleset, PHPCompatibility found two PHP cross-version compatibility bugs in the actual polyfills ;-)
These have both been reported upstream.

Bug reports:
* symfony/polyfill#499#issuecomment-3430297592
* symfony/polyfill#550
 
Additionally, PHPCompatibility correctly detected that the PHP 8.3 polyfills were not in actual fact compatible with PHP 7.1. This was "fixed" in version 1.31.0 when support for PHP 7.1 was dropped.

