### PR TITLE
Add `PHPCompatibilitySymfonyPolyfillPHP84` ruleset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           diff -B ./PHPCompatibilitySymfonyPolyfillPHP81/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP81/ruleset.xml")
           diff -B ./PHPCompatibilitySymfonyPolyfillPHP82/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP82/ruleset.xml")
           diff -B ./PHPCompatibilitySymfonyPolyfillPHP83/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP83/ruleset.xml")
+          diff -B ./PHPCompatibilitySymfonyPolyfillPHP84/ruleset.xml <(xmllint --format "./PHPCompatibilitySymfonyPolyfillPHP84/ruleset.xml")
 
   test:
     # Don't run the cron job on forks.
@@ -111,13 +112,13 @@ jobs:
           # Remove the PHP 8.x polyfills on PHP < 7 as the minimum requirement is PHP 7.1 and the autoloading
           # of the polyfill bootstrap file via Composer would generate a parse error, blocking the DealerDirect plugin
           # from setting the installed_paths for PHPCS.
-          composer remove --dev symfony/polyfill-php80 symfony/polyfill-php81 symfony/polyfill-php82 symfony/polyfill-php83 --no-update --no-scripts --no-interaction
+          composer remove --dev symfony/polyfill-php80 symfony/polyfill-php81 symfony/polyfill-php82 symfony/polyfill-php83 symfony/polyfill-php84 --no-update --no-scripts --no-interaction
           composer require --no-update symfony/polyfill-php72:"1.19" symfony/polyfill-php73:"1.19" symfony/polyfill-php74:"1.19" --no-interaction
 
       - name: "Conditionally require specific versions of the polyfills (PHP 7.1)"
         if: ${{ matrix.php == '7.1' }}
         run: |
-          composer require --no-update symfony/polyfill-php73:"1.30" symfony/polyfill-php74:"1.30" symfony/polyfill-php80:"1.30" symfony/polyfill-php81:"1.30" symfony/polyfill-php82:"1.30" symfony/polyfill-php83:"1.30" --no-interaction
+          composer require --no-update symfony/polyfill-php73:"1.30" symfony/polyfill-php74:"1.30" symfony/polyfill-php80:"1.30" symfony/polyfill-php81:"1.30" symfony/polyfill-php82:"1.30" symfony/polyfill-php83:"1.30" symfony/polyfill-php84:"1.30" --no-interaction
 
       - name: Conditionally update PHPCompatibility to develop version
         if: ${{ matrix.phpcompat != 'stable' }}
@@ -153,6 +154,7 @@ jobs:
           vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP81Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP81  --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
           vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP82Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP82 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
           vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP83Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP83 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
+          vendor/bin/phpcs -ps ./Test/SymfonyPolyfillPHP84Test.php --standard=PHPCompatibilitySymfonyPolyfillPHP84 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
 
       # Check that the rulesets don't throw unnecessary errors for the compat libraries themselves.
       # Note: the polyfills for PHP 5.4 - 7.1 have been decoupled from the monorepo at version 1.19.
@@ -186,6 +188,7 @@ jobs:
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php82/ --standard=PHPCompatibilitySymfonyPolyfillPHP82 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
           # The PHP 8.3 polyfills at version 1.30 are not tested against PHP 7.1 as they are not in actual fact
           # compatible with PHP 7.1. This was correctly detected by PHPCompatibility and would cause this test to fail.
+          vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php84/ --standard=PHPCompatibilitySymfonyPolyfillPHP84 --exclude=PHPCompatibility.Upgrade.LowPHP --runtime-set testVersion 7.1-
 
       # The polyfills for PHP 7.3 and higher are compatible with PHP 7.2+ at the current version.
       - name: "Test running against the polyfills - polyfills 7.3- (current)"
@@ -197,3 +200,4 @@ jobs:
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php81/ --standard=PHPCompatibilitySymfonyPolyfillPHP81 --runtime-set testVersion 7.2-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php82/ --standard=PHPCompatibilitySymfonyPolyfillPHP82 --runtime-set testVersion 7.2-
           vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php83/ --standard=PHPCompatibilitySymfonyPolyfillPHP83 --runtime-set testVersion 7.2-
+          vendor/bin/phpcs -ps ./vendor/symfony/polyfill-php84/ --standard=PHPCompatibilitySymfonyPolyfillPHP84 --runtime-set testVersion 7.2-

--- a/PHPCompatibilitySymfonyPolyfillPHP84/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP84/ruleset.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilitySymfonyPolyfillPHP84" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
+    <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 8.4 library.</description>
+
+    <rule ref="PHPCompatibility">
+        <!-- https://github.com/symfony/polyfill-php84/blob/master/bootstrap.php -->
+        <exclude name="PHPCompatibility.Constants.NewConstants.curl_http_version_3Found"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.curl_http_version_3onlyFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_findFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_find_keyFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_anyFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_allFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.fpowFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.mb_ucfirstFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.mb_lcfirstFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.mb_trimFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.mb_ltrimFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.mb_rtrimFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.bcdivmodFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.grapheme_str_splitFound"/>
+
+        <!-- https://github.com/symfony/polyfill-php84/tree/main/Resources/stubs -->
+        <!--
+        Detection for the Deprecated attribute is incomplete in PHPCompatibility 10.0.0-alpha1.
+        Handling for this should be added once the detection implementation is known.
+        The following exclude is a temporary placeholder, which should be removed as soon as
+        possible as it will ignore too much.
+        -->
+        <exclude name="PHPCompatibility.Attributes.NewAttributes.PHPStormAttributeFound"/>
+
+        <exclude name="PHPCompatibility.Classes.NewClasses.reflectionconstantFound"/>
+    </rule>
+
+    <!-- Prevent false positives being thrown when run over the code of polyfill-php83 itself. -->
+    <rule ref="PHPCompatibility.FunctionUse.RequiredToOptionalFunctionParameters.bcscale_scaleMissing">
+        <exclude-pattern>/polyfill-php84/Php84\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.Attributes.NewAttributes.PHPNativeAttributeFound">
+        <exclude-pattern>/polyfill-php84/Resources/stubs/Deprecated\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.Classes.NewClasses.attributeFound">
+        <exclude-pattern>/polyfill-php84/Resources/stubs/Deprecated\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.FunctionUse.NewFunctions.get_debug_typeFound">
+        <exclude-pattern>/polyfill-php84/Resources/stubs/ReflectionConstant\.php$</exclude-pattern>
+    </rule>
+
+    <!-- This is fine as the autoloading for this file should only ever be triggered when on PHP 8.0 or higher. -->
+    <rule ref="PHPCompatibility.Classes.NewTypedProperties.Found">
+        <exclude-pattern>/polyfill-php84/Resources/stubs/Deprecated\.php$</exclude-pattern>
+    </rule>
+
+    <!-- These are fine as this file will only be used for PHP 8.2 and 8.3. -->
+    <rule ref="PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.UnionTypeFound">
+        <exclude-pattern>/polyfill-php84/bootstrap82\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.falseFound">
+        <exclude-pattern>/polyfill-php84/bootstrap82\.php$</exclude-pattern>
+    </rule>
+
+    <!--
+    Not a false positive, but a bug in the Symfony PHP 8.4 polyfill package.
+    Bug has been reported: https://github.com/symfony/polyfill/issues/499#issuecomment-3430423298
+    Temporarily silencing the error as this needs to be solved upstream.
+    -->
+    <rule ref="PHPCompatibility.Classes.NewClasses.valueerrorFound">
+        <exclude-pattern>/polyfill-php84/Php84\.php$</exclude-pattern>
+    </rule>
+
+    <!--
+    Not a false positive, but a bug in the Symfony PHP 8.4 polyfill package.
+    Bug has been reported: https://github.com/symfony/polyfill/issues/551
+    Temporarily silencing the error as this needs to be solved upstream.
+    -->
+    <rule ref="PHPCompatibility.Classes.NewReadonlyProperties.Found">
+        <exclude-pattern>/polyfill-php84/Resources/stubs/Deprecated\.php$</exclude-pattern>
+    </rule>
+
+</ruleset>

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ These rulesets prevent false positives from the [PHPCompatibility standard][PHPC
 | [`polyfill-php81`]       | `PHPCompatibilitySymfonyPolyfillPHP81` |                                                                      |
 | [`polyfill-php82`]       | `PHPCompatibilitySymfonyPolyfillPHP82` |                                                                      |
 | [`polyfill-php83`]       | `PHPCompatibilitySymfonyPolyfillPHP83` |                                                                      |
+| [`polyfill-php84`]       | `PHPCompatibilitySymfonyPolyfillPHP84` |                                                                      |
 
 > [!NOTE]
 > About "Includes":  
@@ -103,6 +104,7 @@ vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP80
 vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP81
 vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP82
 vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP83
+vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP84
 
 # You can also combine the standards if your project uses several:
 vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP55,PHPCompatibilitySymfonyPolyfillPHP70,PHPCompatibilitySymfonyPolyfillPHP73
@@ -159,3 +161,4 @@ All code within the PHPCompatibility organisation is released under the GNU Less
 [`polyfill-php81`]:           https://github.com/symfony/polyfill-php81
 [`polyfill-php82`]:           https://github.com/symfony/polyfill-php82
 [`polyfill-php83`]:           https://github.com/symfony/polyfill-php83
+[`polyfill-php84`]:           https://github.com/symfony/polyfill-php84

--- a/Test/SymfonyPolyfillPHP84Test.php
+++ b/Test/SymfonyPolyfillPHP84Test.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * Test file to run PHP_CodeSniffer against to make sure the polyfills are correctly excluded.
+ */
+
+echo CURL_HTTP_VERSION_3;
+echo CURL_HTTP_VERSION_3ONLY;
+
+array_find($array, $callback);
+array_find_key($array, $callback);
+array_any($array, $callback);
+array_all($array, $callback);
+fpow($num, $exponent);
+
+echo mb_ucfirst($string);
+echo mb_lcfirst($string);
+mb_trim($string);
+mb_ltrim($string);
+mb_rtrim($string);
+
+bcdivmod($num1, $num2);
+
+grapheme_str_split($string);
+
+$r = new ReflectionConstant(ClassName::CONSTANT_NAME);
+
+#[Deprecated]
+function foo() {}

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
     "symfony/polyfill-php80": "1.x-dev",
     "symfony/polyfill-php81": "1.x-dev",
     "symfony/polyfill-php82": "1.x-dev",
-    "symfony/polyfill-php83": "1.x-dev"
+    "symfony/polyfill-php83": "1.x-dev",
+    "symfony/polyfill-php84": "1.x-dev"
   },
   "prefer-stable" : true
 }


### PR DESCRIPTION
The Symfony project has released a [polyfill library for PHP 8.4](https://github.com/symfony/polyfill-php84) and what with the release of PHPCompatibility 10.0.0-alpha1, features polyfilled by that library would now be flagged.

This adds a corresponding PHPCompatibility ruleset for this polyfill.

Includes integration test.

Note: while creating this polyfill ruleset, PHPCompatibility found two PHP cross-version compatibility bugs in the actual polyfills ;-) These have both been reported upstream.

Bug reports:
* symfony/polyfill#499#issuecomment-3430423298
* symfony/polyfill#551