### PR TITLE
Fix links after upstream branch rename

### DIFF
--- a/PHPCompatibilitySymfonyPolyfillPHP54/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP54/ruleset.xml
@@ -4,13 +4,13 @@
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 5.4 library.</description>
 
     <rule ref="PHPCompatibility">
-        <!-- https://github.com/symfony/polyfill-php54/blob/main/bootstrap.php -->
+        <!-- https://github.com/symfony/polyfill-php54/blob/v1.19.0/bootstrap.php -->
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.trait_existsFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.class_usesFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hex2binFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.session_register_shutdownFound"/>
 
-        <!-- https://github.com/symfony/polyfill-php54/tree/main/Resources/stubs -->
+        <!-- https://github.com/symfony/polyfill-php54/tree/v1.19.0/Resources/stubs -->
         <exclude name="PHPCompatibility.Classes.NewClasses.callbackfilteriteratorFound"/>
         <exclude name="PHPCompatibility.Classes.NewClasses.recursivecallbackfilteriteratorFound"/>
         <exclude name="PHPCompatibility.Interfaces.NewInterfaces.sessionhandlerinterfaceFound"/>

--- a/PHPCompatibilitySymfonyPolyfillPHP55/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP55/ruleset.xml
@@ -3,11 +3,11 @@
 
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 5.5 library.</description>
 
-    <!-- https://github.com/symfony/polyfill-php55/blob/main/composer.json -->
+    <!-- https://github.com/symfony/polyfill-php55/blob/v1.19.0/composer.json -->
     <rule ref="PHPCompatibilityPasswordCompat"/>
 
     <rule ref="PHPCompatibility">
-        <!-- https://github.com/symfony/polyfill-php55/blob/main/bootstrap.php -->
+        <!-- https://github.com/symfony/polyfill-php55/blob/v1.19.0/bootstrap.php -->
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_columnFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.boolvalFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hash_pbkdf2Found"/>

--- a/PHPCompatibilitySymfonyPolyfillPHP56/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP56/ruleset.xml
@@ -4,7 +4,7 @@
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 5.6 libary.</description>
 
     <rule ref="PHPCompatibility">
-        <!-- https://github.com/symfony/polyfill-php56/blob/main/bootstrap.php -->
+        <!-- https://github.com/symfony/polyfill-php56/blob/v1.19.0/bootstrap.php -->
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hash_equalsFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.ldap_escapeFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.ldap_escape_filterFound"/>

--- a/PHPCompatibilitySymfonyPolyfillPHP70/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP70/ruleset.xml
@@ -3,17 +3,17 @@
 
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 7.0 library.</description>
 
-    <!-- https://github.com/symfony/polyfill-php70/blob/main/composer.json -->
+    <!-- https://github.com/symfony/polyfill-php70/blob/v1.19.0/composer.json -->
     <rule ref="PHPCompatibilityParagonieRandomCompat"/>
 
     <rule ref="PHPCompatibility">
-        <!-- https://github.com/symfony/polyfill-php70/blob/main/bootstrap.php -->
+        <!-- https://github.com/symfony/polyfill-php70/blob/v1.19.0/bootstrap.php -->
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.intdivFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.preg_replace_callback_arrayFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.error_clear_lastFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.php_int_minFound"/>
 
-        <!-- https://github.com/symfony/polyfill-php70/tree/main/Resources/stubs -->
+        <!-- https://github.com/symfony/polyfill-php70/tree/v1.19.0/Resources/stubs -->
         <exclude name="PHPCompatibility.Classes.NewClasses.errorFound"/>
         <exclude name="PHPCompatibility.Classes.NewClasses.arithmeticerrorFound"/>
         <exclude name="PHPCompatibility.Classes.NewClasses.assertionerrorFound"/>

--- a/PHPCompatibilitySymfonyPolyfillPHP71/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP71/ruleset.xml
@@ -4,7 +4,7 @@
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 7.1 library.</description>
 
     <rule ref="PHPCompatibility">
-        <!-- https://github.com/symfony/polyfill-php71/blob/main/bootstrap.php -->
+        <!-- https://github.com/symfony/polyfill-php71/blob/v1.19.0/bootstrap.php -->
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.is_iterableFound"/>
     </rule>
 

--- a/PHPCompatibilitySymfonyPolyfillPHP72/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP72/ruleset.xml
@@ -4,7 +4,7 @@
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 7.2 library.</description>
 
     <rule ref="PHPCompatibility">
-        <!-- https://github.com/symfony/polyfill-php72/blob/main/bootstrap.php -->
+        <!-- https://github.com/symfony/polyfill-php72/blob/v1.30.0/bootstrap.php -->
         <exclude name="PHPCompatibility.Constants.NewConstants.php_float_digFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.php_float_epsilonFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.php_float_minFound"/>

--- a/PHPCompatibilitySymfonyPolyfillPHP73/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP73/ruleset.xml
@@ -4,7 +4,7 @@
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 7.3 library.</description>
 
     <rule ref="PHPCompatibility">
-        <!-- https://github.com/symfony/polyfill-php73/blob/main/bootstrap.php -->
+        <!-- https://github.com/symfony/polyfill-php73/blob/1.x/bootstrap.php -->
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_key_firstFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_key_lastFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hrtimeFound"/>

--- a/PHPCompatibilitySymfonyPolyfillPHP74/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP74/ruleset.xml
@@ -4,7 +4,7 @@
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 7.4 library.</description>
 
     <rule ref="PHPCompatibility">
-        <!-- https://github.com/symfony/polyfill-php74/blob/main/bootstrap.php -->
+        <!-- https://github.com/symfony/polyfill-php74/blob/1.x/bootstrap.php -->
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.get_mangled_object_varsFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.mb_str_splitFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.password_algosFound"/>

--- a/PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP80/ruleset.xml
@@ -4,7 +4,7 @@
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 8.0 library.</description>
 
     <rule ref="PHPCompatibility">
-        <!-- https://github.com/symfony/polyfill-php80/blob/main/bootstrap.php -->
+        <!-- https://github.com/symfony/polyfill-php80/blob/1.x/bootstrap.php -->
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.fdivFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.get_resource_idFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.preg_last_error_msgFound"/>
@@ -14,7 +14,7 @@
         <exclude name="PHPCompatibility.Constants.NewConstants.filter_validate_boolFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.get_debug_typeFound"/>
 
-        <!-- https://github.com/symfony/polyfill-php80/tree/main/Resources/stubs -->
+        <!-- https://github.com/symfony/polyfill-php80/tree/1.x/Resources/stubs -->
         <exclude name="PHPCompatibility.Interfaces.NewInterfaces.stringableFound"/>
         <exclude name="PHPCompatibility.Classes.NewClasses.attributeFound"/>
         <exclude name="PHPCompatibility.Classes.NewClasses.phptokenFound"/>

--- a/PHPCompatibilitySymfonyPolyfillPHP81/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP81/ruleset.xml
@@ -4,13 +4,13 @@
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 8.1 library.</description>
 
     <rule ref="PHPCompatibility">
-        <!-- https://github.com/symfony/polyfill-php81/blob/main/bootstrap.php -->
+        <!-- https://github.com/symfony/polyfill-php81/blob/1.x/bootstrap.php -->
         <exclude name="PHPCompatibility.Constants.NewConstants.mysqli_refresh_replicaFound"/>
         <exclude name="PHPCompatibility.Constants.RemovedConstants.mysqli_refresh_replicaDeprecated"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_is_listFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.enum_existsFound"/>
 
-        <!-- https://github.com/symfony/polyfill-php81/tree/main/Resources/stubs -->
+        <!-- https://github.com/symfony/polyfill-php81/tree/1.x/Resources/stubs -->
         <exclude name="PHPCompatibility.Classes.NewClasses.curlstringfileFound"/>
     </rule>
 

--- a/PHPCompatibilitySymfonyPolyfillPHP82/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP82/ruleset.xml
@@ -4,19 +4,19 @@
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 8.2 library.</description>
 
     <rule ref="PHPCompatibility">
-        <!-- https://github.com/symfony/polyfill-php82/blob/master/bootstrap.php -->
+        <!-- https://github.com/symfony/polyfill-php82/blob/1.x/bootstrap.php -->
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.odbc_connection_string_is_quotedFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.odbc_connection_string_should_quoteFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.odbc_connection_string_quoteFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.ini_parse_quantityFound"/>
 
-        <!-- https://github.com/symfony/polyfill-php82/tree/main/Resources/stubs -->
+        <!-- https://github.com/symfony/polyfill-php82/tree/1.x/Resources/stubs -->
         <!--
         Detection for the AllowDynamicProperties and SensitiveParameter attributes is incomplete in PHPCompatibility 10.0.0-alpha1.
         This section should be filled out once the detection implementation is known.
         -->
 
-        <!-- https://github.com/symfony/polyfill-php82/tree/main/Resources/stubs/Random -->
+        <!-- https://github.com/symfony/polyfill-php82/tree/1.x/Resources/stubs/Random -->
         <exclude name="PHPCompatibility.Classes.NewClasses.random_brokenrandomengineerrorFound"/>
         <exclude name="PHPCompatibility.Classes.NewClasses.random_randomerrorFound"/>
         <exclude name="PHPCompatibility.Classes.NewClasses.random_randomexceptionFound"/>

--- a/PHPCompatibilitySymfonyPolyfillPHP83/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP83/ruleset.xml
@@ -4,7 +4,7 @@
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 8.3 library.</description>
 
     <rule ref="PHPCompatibility">
-        <!-- https://github.com/symfony/polyfill-php83/blob/master/bootstrap.php -->
+        <!-- https://github.com/symfony/polyfill-php83/blob/1.x/bootstrap.php -->
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_validateFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.mb_str_padFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.stream_context_set_optionsFound"/>
@@ -13,9 +13,9 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.ldap_exop_syncFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.ldap_connect_walletFound"/>
 
-        <!-- https://github.com/symfony/polyfill-php83/tree/main/Resources/stubs -->
+        <!-- https://github.com/symfony/polyfill-php83/tree/1.x/Resources/stubs -->
         <!--
-        Detection for the Override attributes is incomplete in PHPCompatibility 10.0.0-alpha1.
+        Detection for the Override attribute is incomplete in PHPCompatibility 10.0.0-alpha1.
         Handling for this should be added once the detection implementation is known.
         -->
         <exclude name="PHPCompatibility.Classes.NewClasses.dateerrorFound"/>

--- a/PHPCompatibilitySymfonyPolyfillPHP84/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP84/ruleset.xml
@@ -4,7 +4,7 @@
     <description>PHPCompatibility ruleset for PHP_CodeSniffer which accounts for polyfills provided by the Symfony PHP 8.4 library.</description>
 
     <rule ref="PHPCompatibility">
-        <!-- https://github.com/symfony/polyfill-php84/blob/master/bootstrap.php -->
+        <!-- https://github.com/symfony/polyfill-php84/blob/1.x/bootstrap.php -->
         <exclude name="PHPCompatibility.Constants.NewConstants.curl_http_version_3Found"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.curl_http_version_3onlyFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_findFound"/>
@@ -20,7 +20,7 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.bcdivmodFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.grapheme_str_splitFound"/>
 
-        <!-- https://github.com/symfony/polyfill-php84/tree/main/Resources/stubs -->
+        <!-- https://github.com/symfony/polyfill-php84/tree/1.x/Resources/stubs -->
         <!--
         Detection for the Deprecated attribute is incomplete in PHPCompatibility 10.0.0-alpha1.
         Handling for this should be added once the detection implementation is known.
@@ -32,7 +32,7 @@
         <exclude name="PHPCompatibility.Classes.NewClasses.reflectionconstantFound"/>
     </rule>
 
-    <!-- Prevent false positives being thrown when run over the code of polyfill-php83 itself. -->
+    <!-- Prevent false positives being thrown when run over the code of polyfill-php84 itself. -->
     <rule ref="PHPCompatibility.FunctionUse.RequiredToOptionalFunctionParameters.bcscale_scaleMissing">
         <exclude-pattern>/polyfill-php84/Php84\.php$</exclude-pattern>
     </rule>

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ These rulesets prevent false positives from the [PHPCompatibility standard][PHPC
 > Some polyfills have other polyfills as dependencies. If the PHPCompatibility project offers a dedicated ruleset for the polyfill dependency, that ruleset will be included in the ruleset for the higher level polyfill.
 >
 > For example:  
-> As the `polyfill-php70` library declares `random_compat` [as a dependency](https://github.com/symfony/polyfill-php70/blob/master/composer.json), the `PHPCompatibilitySymfonyPolyfillPHP70` ruleset includes the `PHPCompatibilityParagonieRandomCompat` ruleset.
+> As the `polyfill-php70` library declares `random_compat` [as a dependency](https://github.com/symfony/polyfill-php70/blob/v1.19.0/composer.json), the `PHPCompatibilitySymfonyPolyfillPHP70` ruleset includes the `PHPCompatibilityParagonieRandomCompat` ruleset.
 >
 > In practice, this means that if your project uses several polyfills, you can use the information in "Includes" to help you decide which rulesets to use.
 


### PR DESCRIPTION
The Symfony project renamed the `master` branch to `main` and now to `1.x`.

Aside from that a number of polyfills are no longer actively maintained, which means that on the `1.x` branch, the repo is now empty, so we should link to the last useful release.

Includes fixing two typos.