### PR TITLE
PHP 8.4 polyfill: update the ruleset for PDO classes / sync with v1.34.0

### DIFF
--- a/PHPCompatibilitySymfonyPolyfillPHP84/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP84/ruleset.xml
@@ -25,7 +25,12 @@
         Detection for the Deprecated attribute is incomplete in PHPCompatibility 10.0.0-alpha1.
         Handling for this should be added once the detection implementation is known.
         -->
-
+        <exclude name="PHPCompatibility.Classes.NewClasses.pdo_dblibFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.pdo_firebirdFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.pdo_mysqlFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.pdo_odbcFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.pdo_pgsqlFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.pdo_sqliteFound"/>
         <exclude name="PHPCompatibility.Classes.NewClasses.reflectionconstantFound"/>
     </rule>
 
@@ -41,6 +46,10 @@
     </rule>
     <rule ref="PHPCompatibility.FunctionUse.NewFunctions.get_debug_typeFound">
         <exclude-pattern>/polyfill-php84/Resources/stubs/ReflectionConstant\.php$</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.Namespaces.ReservedNames.pdoFound">
+        <exclude-pattern>/polyfill-php84/Resources/stubs/Pdo/(Dblib|Firebird|Mysql|Odbc|Pgsql|Sqlite)\.php$</exclude-pattern>
     </rule>
 
     <!-- This is fine as the autoloading for this file should only ever be triggered when on PHP 8.0 or higher. -->

--- a/Test/SymfonyPolyfillPHP84Test.php
+++ b/Test/SymfonyPolyfillPHP84Test.php
@@ -30,3 +30,11 @@ $r = new ReflectionConstant(ClassName::CONSTANT_NAME);
 #[Deprecated]
 function foo() {}
 */
+
+$db = new Pdo\Dblib;
+$db = new \Pdo\Firebird;
+function doSomething(
+    Pdo\Mysql $db
+) : Pdo\Odbc {}
+$db = new Pdo\Pgsql;
+$db = new \Pdo\Sqlite;


### PR DESCRIPTION
As of version v1.34.0, the PDO driver specific sub-classes as introduced in PHP 8.4 are now included in the Symfony polyfill.

Ref:
* symfony/polyfill#549
* https://github.com/symfony/polyfill/commit/d78a0565914a52a2a6e846b4cefb02f59a6a0b05