### PR TITLE
PHP 8.4 polyfill: update the ruleset for bc*() function / sync with v1.34.0

### DIFF
--- a/PHPCompatibilitySymfonyPolyfillPHP84/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP84/ruleset.xml
@@ -17,7 +17,10 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.mb_trimFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.mb_ltrimFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.mb_rtrimFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.bcceilFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.bcdivmodFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.bcfloorFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.bcroundFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.grapheme_str_splitFound"/>
 
         <!-- https://github.com/symfony/polyfill-php84/tree/1.x/Resources/stubs -->
@@ -66,6 +69,11 @@
     </rule>
     <rule ref="PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.falseFound">
         <exclude-pattern>/polyfill-php84/bootstrap82\.php$</exclude-pattern>
+    </rule>
+
+    <!-- This is fine as this file will only be used for PHP 8.1 - 8.3. -->
+    <rule ref="PHPCompatibility.Keywords.NewKeywords.t_enumFound">
+        <exclude-pattern>/polyfill-php84/Resources/RoundingMode\.php$</exclude-pattern>
     </rule>
 
     <!--

--- a/Test/SymfonyPolyfillPHP84Test.php
+++ b/Test/SymfonyPolyfillPHP84Test.php
@@ -38,3 +38,7 @@ function doSomething(
 ) : Pdo\Odbc {}
 $db = new Pdo\Pgsql;
 $db = new \Pdo\Sqlite;
+
+bcceil($num);
+bcfloor($num);
+bcround($num, 2, RoundingMode::HalfAwayFromZero);


### PR DESCRIPTION
As of version v1.34.0, the BCMath `bcceil()`, `bcfloor()` and `bcround()` functions, as introduced in PHP 8.4, are now included in the Symfony polyfill.

Note: the upstream commit also polyfills the PHP `RoundingMode` enum, however, PHPCompatibility doesn't detect this yet, so this will need to be dealt with at a later point in time once it becomes clear how PHPCompatibility will report on this. A test for the enum has been added to ensure that the tests for this package will start failing once PHPCompatibility addresses this.

Ref:
* symfony/polyfill#546
* https://github.com/symfony/polyfill/commit/7846989b4f2df4b38ee2e2cc2ead42b93ec100c0