### PR TITLE
PHP 8.5 polyfill: update the ruleset for Filter exception classes / sync with v1.34.0

### DIFF
--- a/PHPCompatibilitySymfonyPolyfillPHP85/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP85/ruleset.xml
@@ -15,6 +15,8 @@
         Detection for the DelayedTargetValidation and NoDiscard attributes is incomplete in PHPCompatibility 10.0.0-alpha1.
         This section should be filled out once the detection implementation is known.
         -->
+        <exclude name="PHPCompatibility.Classes.NewClasses.filter_filterexceptionFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.filter_filterfailedexceptionFound"/>
     </rule>
 
     <!-- Prevent false positives being thrown when run over the code of polyfill-php84 itself. -->
@@ -25,6 +27,10 @@
     <rule ref="PHPCompatibility.Classes.NewClasses.attributeFound">
         <exclude-pattern>/polyfill-php85/Resources/stubs/DelayedTargetValidation\.php$</exclude-pattern>
         <exclude-pattern>/polyfill-php85/Resources/stubs/NoDiscard\.php$</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.Namespaces.ReservedNames.filterFound">
+        <exclude-pattern>/polyfill-php85/Resources/stubs/Filter/Filter*Exception\.php$</exclude-pattern>
     </rule>
 
     <!-- This is fine as the autoloading for this file should only ever be triggered when on PHP 8.0 or higher. -->

--- a/Test/SymfonyPolyfillPHP85Test.php
+++ b/Test/SymfonyPolyfillPHP85Test.php
@@ -15,3 +15,6 @@ array_last($array);
 #[NoDiscard]
 function dummy() {}
 */
+
+try {
+} catch (Filter\FilterException | Filter\FilterFailedException $e) {}


### PR DESCRIPTION

As of version v1.34.0, the Filter exception classes as introduced in PHP 8.5 are now included in the Symfony polyfill.

Ref:
* symfony/polyfill#557
* https://github.com/symfony/polyfill/commit/a15aef4592827a577d9008c2da2ada64c4cf4fa3