### PR TITLE
PHP 8.5 polyfill: update the ruleset for locale_is_right_to_left() function / sync with v1.34.0

### DIFF
--- a/PHPCompatibilitySymfonyPolyfillPHP85/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP85/ruleset.xml
@@ -9,6 +9,7 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.get_exception_handlerFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_firstFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_lastFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.locale_is_right_to_leftFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.grapheme_levenshteinFound"/>
 
         <!-- https://github.com/symfony/polyfill-php85/tree/1.x/Resources/stubs -->

--- a/Test/SymfonyPolyfillPHP85Test.php
+++ b/Test/SymfonyPolyfillPHP85Test.php
@@ -19,4 +19,5 @@ function dummy() {}
 try {
 } catch (Filter\FilterException | Filter\FilterFailedException $e) {}
 
+locale_is_right_to_left($locale);
 grapheme_levenshtein( $s1, $s2 );


### PR DESCRIPTION

As of version v1.34.0, the Intl `locale_is_right_to_left()` function as introduced in PHP 8.5 is now included in the Symfony polyfill.

Ref:
* symfony/polyfill#527
* https://github.com/symfony/polyfill/commit/46005a73e7b9961d2a8d98a6d5c06dd9e22372d0