### PR TITLE
PHP 8.1 + 8.2 polyfills: update the rulesets / sync with v1.38.1

### DIFF
--- a/PHPCompatibilitySymfonyPolyfillPHP81/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP81/ruleset.xml
@@ -5,6 +5,7 @@
 
     <rule ref="PHPCompatibility">
         <!-- https://github.com/symfony/polyfill-php81/blob/1.x/bootstrap.php -->
+        <exclude name="PHPCompatibility.Constants.NewConstants.curlopt_issuercert_blobFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.mysqli_refresh_replicaFound"/>
         <exclude name="PHPCompatibility.Constants.RemovedConstants.mysqli_refresh_replicaDeprecated"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_is_listFound"/>

--- a/PHPCompatibilitySymfonyPolyfillPHP82/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP82/ruleset.xml
@@ -5,6 +5,7 @@
 
     <rule ref="PHPCompatibility">
         <!-- https://github.com/symfony/polyfill-php82/blob/1.x/bootstrap.php -->
+        <exclude name="PHPCompatibility.Constants.NewConstants.curlopt_ssh_host_public_key_sha256Found"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.odbc_connection_string_is_quotedFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.odbc_connection_string_should_quoteFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.odbc_connection_string_quoteFound"/>

--- a/Test/SymfonyPolyfillPHP81Test.php
+++ b/Test/SymfonyPolyfillPHP81Test.php
@@ -12,3 +12,5 @@ echo MYSQLI_REFRESH_REPLICA;
 class Foo extends ReturnTypeWillChange {}
 
 $file = new CURLStringFile();
+
+echo CURLOPT_ISSUERCERT_BLOB;

--- a/Test/SymfonyPolyfillPHP82Test.php
+++ b/Test/SymfonyPolyfillPHP82Test.php
@@ -36,3 +36,5 @@ function hasSensitiveData(
     string $password
 ) {}
 */
+
+echo CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256;


### PR DESCRIPTION
Two Curl constants, introduced in PHP 8.1 and 8.2, are now polyfilled via the Symfony polyfills as per v 1.38.1.

Ref:
* symfony/polyfill#617
* https://github.com/symfony/polyfill/commit/b8eb47343cdcd6b3c4eee64f55c20ca0c41780ee