### PR TITLE
PHP 7.4, 8.3 + 8.5 polyfills: update the rulesets / sync with v1.4x.x

### DIFF
--- a/PHPCompatibilitySymfonyPolyfillPHP74/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP74/ruleset.xml
@@ -21,4 +21,9 @@
         <exclude-pattern>/polyfill[_-]php74/Php74\.php$</exclude-pattern>
     </rule>
 
+    <!-- Version toggle present. See: https://github.com/symfony/polyfill/pull/640 -->
+    <rule ref="PHPCompatibility.Classes.NewClasses.valueerrorFound">
+        <exclude-pattern>/polyfill[_-]php74/Php74\.php$</exclude-pattern>
+    </rule>
+
 </ruleset>

--- a/PHPCompatibilitySymfonyPolyfillPHP83/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP83/ruleset.xml
@@ -15,6 +15,10 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.ldap_exop_syncFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.ldap_connect_walletFound"/>
 
+        <!-- This is a PHP 8.0 feature, but is polyfilled in the PHP 8.3 package to polyfill certain PHP 8.3 features properly. -->
+        <!-- See: https://github.com/symfony/polyfill/pull/637 -->
+        <exclude name="PHPCompatibility.Classes.NewClasses.valueerrorFound"/>
+
         <!-- https://github.com/symfony/polyfill-php83/tree/1.x/Resources/stubs -->
         <!--
         Detection for the Override attribute is incomplete in PHPCompatibility 10.0.0-alpha1.
@@ -77,11 +81,6 @@
     </rule>
     <rule ref="PHPCompatibility.Attributes.NewAttributes.FoundInline">
         <exclude-pattern>/polyfill-php83/bootstrap81\.php$</exclude-pattern>
-    </rule>
-
-    <!-- Version toggle present. See: https://github.com/symfony/polyfill/pull/501 -->
-    <rule ref="PHPCompatibility.Classes.NewClasses.valueerrorFound">
-        <exclude-pattern>/polyfill-php83/Php83\.php$</exclude-pattern>
     </rule>
 
     <!-- See: https://github.com/symfony/polyfill/pull/594 -->

--- a/PHPCompatibilitySymfonyPolyfillPHP85/ruleset.xml
+++ b/PHPCompatibilitySymfonyPolyfillPHP85/ruleset.xml
@@ -12,6 +12,10 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.locale_is_right_to_leftFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.grapheme_levenshteinFound"/>
 
+        <!-- This is a PHP 8.0 feature, but is polyfilled in the PHP 8.3 package to polyfill certain PHP 8.3 features properly. -->
+        <!-- See: https://github.com/symfony/polyfill/pull/637 -->
+        <exclude name="PHPCompatibility.Classes.NewClasses.valueerrorFound"/>
+
         <!-- https://github.com/symfony/polyfill-php85/tree/1.x/Resources/stubs -->
         <!--
         Detection for the DelayedTargetValidation and NoDiscard attributes is incomplete in PHPCompatibility 10.0.0-alpha1.
@@ -46,15 +50,6 @@
     </rule>
     <rule ref="PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.falseFound">
         <exclude-pattern>/polyfill-php85/bootstrap80\.php$</exclude-pattern>
-    </rule>
-
-    <!--
-    Not a false positive, but a bug in the Symfony PHP 8.5 polyfill package.
-    Bug has been reported: ...
-    Temporarily silencing the error as this needs to be solved upstream.
-    -->
-    <rule ref="PHPCompatibility.Classes.NewClasses.valueerrorFound">
-        <exclude-pattern>/polyfill-php85/Php85\.php$</exclude-pattern>
     </rule>
 
 </ruleset>

--- a/Test/SymfonyPolyfillPHP83Test.php
+++ b/Test/SymfonyPolyfillPHP83Test.php
@@ -24,3 +24,5 @@ try {
 } catch (DateObjectError | DateRangeError $e) {
 } catch (SQLite3Exception $e) {
 }
+
+throw new ValueError();

--- a/Test/SymfonyPolyfillPHP85Test.php
+++ b/Test/SymfonyPolyfillPHP85Test.php
@@ -21,3 +21,5 @@ try {
 
 locale_is_right_to_left($locale);
 grapheme_levenshtein( $s1, $s2 );
+
+throw new ValueError();


### PR DESCRIPTION
In response to an issue I created about this, the PHP 8.3 and 8.5 polyfills now also polyfill the PHP 8.0 `ValueError` and the PHP 7.4 now conditionally throws a `ValueError` (when on PHP >= 8.0).

Ref:
* symfony/polyfill#636
* symfony/polyfill#637
* https://github.com/symfony/polyfill/commit/ef4bfa776bf17577e7043f06b6435451cc626708
* symfony/polyfill#640
* https://github.com/symfony/polyfill/commit/e91b176010305cd8cd7d5e2c7fa81edf91b5d2e9

---

**Note: the upstream fixes have not been released yet!**
